### PR TITLE
Fixed duplicate directory false positive + Set recursive

### DIFF
--- a/src/main/indexables/directoryManager.ts
+++ b/src/main/indexables/directoryManager.ts
@@ -89,9 +89,21 @@ export namespace DirectoryManager {
           : await Tag.findBy({ id: In(payload.autoTags) })
 
       directory.autoTags = nextTags
+    }
 
+    const recursionChanged = directory.recursive != payload.recursive
+    directory.recursive = payload.recursive
+
+    if (tagsChanged || recursionChanged) {
       await directory.save()
-      TaggingManager.bulkTagDirectory(directory)
+
+      if (recursionChanged) {
+        IndexingManager.indexFiles(directory)
+      }
+
+      if (tagsChanged) {
+        TaggingManager.bulkTagDirectory(directory)
+      }
     }
   }
 
@@ -146,7 +158,7 @@ export namespace DirectoryManager {
         })
       ])
 
-      const resultingLength = resultingSearch.length
+      const resultingLength = resultingSearch.filter((d) => !d.isDirectory()).length
 
       return {
         additions: Math.max(0, resultingLength - taggableCount),

--- a/src/renderer/src/Settings/IndexedDirectorySettings/AddDirectory.tsx
+++ b/src/renderer/src/Settings/IndexedDirectorySettings/AddDirectory.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import CreateNewFolderIcon from '@mui/icons-material/CreateNewFolderRounded'
 import { Box, Button, Dialog, DialogContent, DialogTitle, Stack, Typography } from '@mui/material'
 import folderAlreadyExists from './folderAlreadyExists.png'
+import { isSubdirectory } from './isSubdirectory'
 
 export interface AddDirectoryProps {
   directoryState: Impart.Directory[]
@@ -21,7 +22,10 @@ export function AddDirectory({ directoryState, onAdd }: AddDirectoryProps) {
     }
 
     for (const directory of directoryState) {
-      if (directory.path === folder || (directory.recursive && folder.startsWith(directory.path))) {
+      if (
+        directory.path === folder ||
+        (directory.recursive && isSubdirectory(folder, directory.path))
+      ) {
         setConflictingDirectory(directory)
         setLoadedPath(folder)
         setShowConflict(true)

--- a/src/renderer/src/Settings/IndexedDirectorySettings/DirectoryList.tsx
+++ b/src/renderer/src/Settings/IndexedDirectorySettings/DirectoryList.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DirectoryEditor } from './DirectoryEditor'
 import { produce } from 'immer'
+import { isSubdirectory } from './isSubdirectory'
 
 export interface DirectoryListProps {
   directoryState: Impart.Directory[]
@@ -62,7 +63,7 @@ export function DirectoryList({
           directoryState={directoryState.find((state) => state.path === original.path)}
           originalDirectory={original}
           subDirectories={directoryState.filter(
-            (ds) => ds.path != original.path && ds.path.startsWith(original.path)
+            (ds) => ds.path != original.path && isSubdirectory(ds.path, original.path)
           )}
           onChange={(updatedState) => updateDirectory(original.path, updatedState)}
           onDelete={() => onChange(removeDir(original))}
@@ -77,7 +78,7 @@ export function DirectoryList({
             directoryState={state}
             subDirectories={directoryState.filter(
               (otherState) =>
-                state.path != otherState.path && otherState.path.startsWith(state.path)
+                state.path != otherState.path && isSubdirectory(otherState.path, state.path)
             )}
             onChange={(updatedState) => updateDirectory(state.path, updatedState)}
             onDelete={() => onChange(removeDir(state))}

--- a/src/renderer/src/Settings/IndexedDirectorySettings/isSubdirectory.ts
+++ b/src/renderer/src/Settings/IndexedDirectorySettings/isSubdirectory.ts
@@ -1,0 +1,5 @@
+export function isSubdirectory(childPath: string, parentPath: string) {
+  //Seeing as it's a bit cumbersome to check what platform we're currently on, it's easier
+  // to just check both file separate types for recursive directories
+  return childPath.startsWith(parentPath + '\\') || childPath.startsWith(parentPath + '/')
+}


### PR DESCRIPTION
Resolves #4 

Fixed not being able able to add a directory if it "contained" the name of a sibling directory. Additionally:
- Fixed not being able to update the recursive flag on a directory after it's been indexed.
- Fixed the "this will add X files and remove x files" message on directory edit giving inaccurate numbers (it was counting directories as files)

<img width="855" height="662" alt="image" src="https://github.com/user-attachments/assets/df5075eb-a1a5-4a58-81ee-bacd788910e4" />
