### PR TITLE
Default Excluded Tags

### DIFF
--- a/src/main/database/database.ts
+++ b/src/main/database/database.ts
@@ -12,7 +12,7 @@ import { APP_DIR, DEV_DIR } from '../common/appDir'
 import { InitDatabase1730761117956 } from './migrations/1730761117956-InitDatabase'
 import { NsfwTags1746577567101 } from './migrations/1746577567101-nsfwTags'
 import { NsfwPrivateRename1763407600185 } from './migrations/1763407600185-nsfwPrivateRename'
-import { DefaultExcluded1776607995921 } from './migrations/1776607995921-defaultExcluded'
+import { ExcludeByDefault1776607995921 } from './migrations/1776607995921-defaultExcluded'
 
 const path = app.getPath('appData')
 
@@ -33,7 +33,7 @@ export const AppDataSource = new DataSource({
     InitDatabase1730761117956,
     NsfwTags1746577567101,
     NsfwPrivateRename1763407600185,
-    DefaultExcluded1776607995921
+    ExcludeByDefault1776607995921
   ],
   migrationsTableName: '__migrations',
   migrationsRun: true,

--- a/src/main/database/database.ts
+++ b/src/main/database/database.ts
@@ -12,6 +12,7 @@ import { APP_DIR, DEV_DIR } from '../common/appDir'
 import { InitDatabase1730761117956 } from './migrations/1730761117956-InitDatabase'
 import { NsfwTags1746577567101 } from './migrations/1746577567101-nsfwTags'
 import { NsfwPrivateRename1763407600185 } from './migrations/1763407600185-nsfwPrivateRename'
+import { DefaultExcluded1776607995921 } from './migrations/1776607995921-defaultExcluded'
 
 const path = app.getPath('appData')
 
@@ -28,7 +29,12 @@ export const AppDataSource = new DataSource({
     TaggableStack,
     Thumbnail
   ],
-  migrations: [InitDatabase1730761117956, NsfwTags1746577567101, NsfwPrivateRename1763407600185],
+  migrations: [
+    InitDatabase1730761117956,
+    NsfwTags1746577567101,
+    NsfwPrivateRename1763407600185,
+    DefaultExcluded1776607995921
+  ],
   migrationsTableName: '__migrations',
   migrationsRun: true,
   logging: app.isPackaged ? false : ['error', 'warn', 'info']

--- a/src/main/database/entities/Tag.ts
+++ b/src/main/database/entities/Tag.ts
@@ -22,7 +22,7 @@ export class Tag extends BaseEntity {
   isPrivate: boolean
 
   @Column({ nullable: false, default: false })
-  defaultExcluded: boolean
+  excludeByDefault: boolean
 
   @ManyToOne(() => TagGroup, (g) => g.tags, { nullable: false, onDelete: 'CASCADE' })
   group?: TagGroup

--- a/src/main/database/entities/Tag.ts
+++ b/src/main/database/entities/Tag.ts
@@ -21,6 +21,9 @@ export class Tag extends BaseEntity {
   @Column({ nullable: false, default: false })
   isPrivate: boolean
 
+  @Column({ nullable: false, default: false })
+  defaultExcluded: boolean
+
   @ManyToOne(() => TagGroup, (g) => g.tags, { nullable: false, onDelete: 'CASCADE' })
   group?: TagGroup
 

--- a/src/main/database/migrations/1746577567101-nsfwTags.ts
+++ b/src/main/database/migrations/1746577567101-nsfwTags.ts
@@ -2,10 +2,11 @@ import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm'
 
 export class NsfwTags1746577567101 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.query('ALTER TABLE tag ADD isNsfw BOOLEAN DEFAULT (false)')
+    await queryRunner.query('ALTER TABLE tag ADD isNsfw BOOLEAN DEFAULT (false)')
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.dropColumn('tag', 'isNsfw')
+    await queryRunner.dropColumn('tag', 'isNsfw')
   }
 }
+

--- a/src/main/database/migrations/1763407600185-nsfwPrivateRename.ts
+++ b/src/main/database/migrations/1763407600185-nsfwPrivateRename.ts
@@ -2,11 +2,11 @@ import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class NsfwPrivateRename1763407600185 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.query('ALTER TABLE tag RENAME COLUMN isNsfw TO isPrivate')
+    await queryRunner.query('ALTER TABLE tag RENAME COLUMN isNsfw TO isPrivate')
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    queryRunner.query('ALTER TABLE tag RENAME COLUMN isPrivate TO isNsfw')
+    await queryRunner.query('ALTER TABLE tag RENAME COLUMN isPrivate TO isNsfw')
   }
 }
 

--- a/src/main/database/migrations/1776607995921-defaultExcluded.ts
+++ b/src/main/database/migrations/1776607995921-defaultExcluded.ts
@@ -1,14 +1,14 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
-export class DefaultExcluded1776607995921 implements MigrationInterface {
-  name = 'DefaultExcluded1776607995921'
+export class ExcludeByDefault1776607995921 implements MigrationInterface {
+  name = 'ExcludeByDefault1776607995921'
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('ALTER TABLE tag ADD defaultExcluded BOOLEAN DEFAULT (false)')
+    await queryRunner.query('ALTER TABLE tag ADD excludeByDefault BOOLEAN DEFAULT (false)')
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumn('tag', 'defaultExcluded')
+    await queryRunner.dropColumn('tag', 'excludeByDefault')
   }
 }
 

--- a/src/main/database/migrations/1776607995921-defaultExcluded.ts
+++ b/src/main/database/migrations/1776607995921-defaultExcluded.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class DefaultExcluded1776607995921 implements MigrationInterface {
+  name = 'DefaultExcluded1776607995921'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('ALTER TABLE tag ADD defaultExcluded BOOLEAN DEFAULT (false)')
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('tag', 'defaultExcluded')
+  }
+}
+

--- a/src/main/tagging/tagManager.ts
+++ b/src/main/tagging/tagManager.ts
@@ -101,14 +101,19 @@ export namespace TagManager {
     label?: string
     color?: string
     isPrivate: boolean
+    excludeByDefault: boolean
   }
 
-  export async function editTag(tagId: number, { label, color, isPrivate }: TagModel) {
+  export async function editTag(
+    tagId: number,
+    { label, color, isPrivate, excludeByDefault }: TagModel
+  ) {
     const tagEntity = await Tag.findOneByOrFail({ id: tagId })
 
     tagEntity.label = label
     tagEntity.color = color
     tagEntity.isPrivate = isPrivate
+    tagEntity.excludeByDefault = excludeByDefault
 
     await tagEntity.save()
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -81,13 +81,10 @@ declare global {
       tagOrder: number
       color?: string
       isPrivate: boolean
+      excludeByDefault: boolean
     }
 
-    interface TagModel {
-      label?: string
-      color?: string
-      isPrivate: boolean
-    }
+    type TagModel = Omit<Tag, 'id' | 'tagOrder'>
 
     interface TagGroup {
       id: number

--- a/src/renderer/src/Common/Components/Tag/Tag.tsx
+++ b/src/renderer/src/Common/Components/Tag/Tag.tsx
@@ -70,6 +70,8 @@ export function Tag({ tag, selected, editable, onSelect, onExclude, size, exclud
               label: 'Exclude by Default',
               isChecked: tag.excludeByDefault,
               onClick: async () => {
+                const isExcluding = !tag.excludeByDefault
+
                 await window.tagApi.editTag(tag.id, {
                   color: tag.color,
                   label: tag.label,
@@ -77,7 +79,11 @@ export function Tag({ tag, selected, editable, onSelect, onExclude, size, exclud
                   excludeByDefault: !tag.excludeByDefault
                 })
 
-                reload()
+                await reload()
+
+                if (isExcluding != excluded) {
+                  onExclude?.()
+                }
               }
             },
             'divider',

--- a/src/renderer/src/Common/Components/Tag/Tag.tsx
+++ b/src/renderer/src/Common/Components/Tag/Tag.tsx
@@ -59,12 +59,28 @@ export function Tag({ tag, selected, editable, onSelect, onExclude, size, exclud
                 await window.tagApi.editTag(tag.id, {
                   color: tag.color,
                   label: tag.label,
-                  isPrivate: !tag.isPrivate
+                  isPrivate: !tag.isPrivate,
+                  excludeByDefault: tag.excludeByDefault
                 })
 
                 reload()
               }
             },
+            {
+              label: 'Exclude by Default',
+              isChecked: tag.excludeByDefault,
+              onClick: async () => {
+                await window.tagApi.editTag(tag.id, {
+                  color: tag.color,
+                  label: tag.label,
+                  isPrivate: tag.isPrivate,
+                  excludeByDefault: !tag.excludeByDefault
+                })
+
+                reload()
+              }
+            },
+            'divider',
             {
               icon: <DeleteIcon />,
               label: 'Delete',

--- a/src/renderer/src/Common/Components/Tag/TagEditor.tsx
+++ b/src/renderer/src/Common/Components/Tag/TagEditor.tsx
@@ -19,6 +19,7 @@ export function TagEditor({ tag, show, onEdit, onClose }: TagEditorProps) {
   const edit = async () => {
     await window.tagApi.editTag(tag.id, {
       isPrivate: tag.isPrivate,
+      excludeByDefault: tag.isPrivate,
       color: internalColor,
       label: internalLabel
     })

--- a/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
@@ -1,8 +1,6 @@
 import { Box, Stack, Typography, Button, Grid, Divider } from '@mui/material'
-import React from 'react'
 import { Tag } from '../Tag/Tag'
 import FilterAltOffIcon from '@mui/icons-material/FilterAltOffRounded'
-import AddIcon from '@mui/icons-material/Add'
 
 export interface TagSelectionProps {
   selection?: Impart.Tag[]

--- a/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
@@ -2,21 +2,26 @@ import { Box, Stack, Typography, Button, Grid, Divider } from '@mui/material'
 import React from 'react'
 import { Tag } from '../Tag/Tag'
 import FilterAltOffIcon from '@mui/icons-material/FilterAltOffRounded'
+import AddIcon from '@mui/icons-material/Add'
 
 export interface TagSelectionProps {
   selection?: Impart.Tag[]
   exclusion?: Impart.Tag[]
-  onDeselect?: (tag: Impart.Tag) => void
-  onInclude?: (tag: Impart.Tag) => void
+  includedExclusions?: Impart.Tag[]
+  onClickSelected?: (tag: Impart.Tag) => void
+  onClickExcluded?: (tag: Impart.Tag) => void
+  onClickIncludedExclusion?: (tag: Impart.Tag) => void
   onClear?: () => void
 }
 
 export function TagSelection({
   selection,
   exclusion,
+  includedExclusions,
   onClear,
-  onDeselect,
-  onInclude
+  onClickSelected,
+  onClickExcluded,
+  onClickIncludedExclusion
 }: TagSelectionProps) {
   return (
     <Stack pt={1} gap={1}>
@@ -26,25 +31,47 @@ export function TagSelection({
           Clear all
         </Button>
       </Stack>
-      {selection && selection.length > 0 && (
-        <Grid container spacing={2}>
-          {selection.map((t) => (
-            <Grid key={t.id}>
-              <Tag tag={t} onSelect={() => onDeselect && onDeselect(t)} />
+      <Stack gap={1}>
+        {selection && selection.length > 0 && (
+          <>
+            <Divider>Selected</Divider>
+            <Grid container spacing={2}>
+              {selection.map((t) => (
+                <Grid key={t.id}>
+                  <Tag tag={t} onSelect={() => onClickSelected && onClickSelected(t)} />
+                </Grid>
+              ))}
             </Grid>
-          ))}
-        </Grid>
-      )}
-      {selection && selection.length > 0 && exclusion && exclusion.length > 0 && <Divider />}
-      {exclusion && exclusion.length > 0 && (
-        <Grid container spacing={2}>
-          {exclusion?.map((t) => (
-            <Grid key={t.id}>
-              <Tag tag={t} excluded onSelect={() => onInclude && onInclude(t)} />
+          </>
+        )}
+        {exclusion && exclusion.length > 0 && (
+          <>
+            <Divider>Excluded</Divider>
+            <Grid container spacing={2}>
+              {exclusion?.map((t) => (
+                <Grid key={t.id}>
+                  <Tag tag={t} excluded onSelect={() => onClickExcluded && onClickExcluded(t)} />
+                </Grid>
+              ))}
             </Grid>
-          ))}
-        </Grid>
-      )}
+          </>
+        )}
+        {includedExclusions && includedExclusions.length > 0 && (
+          <>
+            <Divider>Included</Divider>
+            <Grid container spacing={2}>
+              {includedExclusions?.map((t) => (
+                <Grid key={t.id}>
+                  <Tag
+                    tag={t}
+                    onSelect={() => onClickIncludedExclusion && onClickIncludedExclusion(t)}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          </>
+        )}
+      </Stack>
     </Stack>
   )
 }

--- a/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagSelection.tsx
@@ -31,10 +31,12 @@ export function TagSelection({
           Clear all
         </Button>
       </Stack>
-      <Stack gap={1}>
+      <Stack>
         {selection && selection.length > 0 && (
-          <>
-            <Divider>Selected</Divider>
+          <Box>
+            <Divider variant="middle">
+              <Typography variant="caption">Selected</Typography>
+            </Divider>
             <Grid container spacing={2}>
               {selection.map((t) => (
                 <Grid key={t.id}>
@@ -42,11 +44,13 @@ export function TagSelection({
                 </Grid>
               ))}
             </Grid>
-          </>
+          </Box>
         )}
         {exclusion && exclusion.length > 0 && (
-          <>
-            <Divider>Excluded</Divider>
+          <Box>
+            <Divider variant="middle">
+              <Typography variant="caption">Excluded</Typography>
+            </Divider>
             <Grid container spacing={2}>
               {exclusion?.map((t) => (
                 <Grid key={t.id}>
@@ -54,11 +58,13 @@ export function TagSelection({
                 </Grid>
               ))}
             </Grid>
-          </>
+          </Box>
         )}
         {includedExclusions && includedExclusions.length > 0 && (
-          <>
-            <Divider>Included</Divider>
+          <Box>
+            <Divider variant="middle">
+              <Typography variant="caption">Included</Typography>
+            </Divider>
             <Grid container spacing={2}>
               {includedExclusions?.map((t) => (
                 <Grid key={t.id}>
@@ -69,7 +75,7 @@ export function TagSelection({
                 </Grid>
               ))}
             </Grid>
-          </>
+          </Box>
         )}
       </Stack>
     </Stack>

--- a/src/renderer/src/Common/Components/TagSelector/TagSelector.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagSelector.tsx
@@ -20,6 +20,10 @@ export interface TagSelectorProps {
   onExclusionChange?: (selection: Impart.Tag[]) => void
 }
 
+function anyHaveValue<T>(...arrays: (T[] | undefined)[]) {
+  return arrays.some((t) => (t?.length ?? 0) > 0)
+}
+
 export function TagSelector({
   selection,
   exclusion,
@@ -46,6 +50,14 @@ export function TagSelector({
   )
 
   const [filter, setFilter] = useState<string>()
+
+  const explicitlyExcludedTags = exclusion?.filter((t) => !t.excludeByDefault)
+  const includedExclusionTags = tags?.filter(
+    (t) =>
+      t.excludeByDefault &&
+      !exclusion?.some((e) => e.id == t.id) &&
+      !selection?.some((s) => s.id == t.id)
+  )
 
   if (groups?.length === 0) {
     return <EmptyTagGroups />
@@ -116,17 +128,19 @@ export function TagSelector({
           )}
         />
       </Stack>
-      {((selection?.length ?? 0) > 0 || (exclusion?.length ?? 0) > 0) && (
+      {anyHaveValue(selection, explicitlyExcludedTags, includedExclusionTags) && (
         <Box position={'sticky'} bgcolor="background.paper" bottom={0} pb={2}>
           <Divider />
           <TagSelection
             selection={selection}
-            exclusion={exclusion}
-            onDeselect={selectItem}
-            onInclude={excludeItem}
+            exclusion={explicitlyExcludedTags}
+            includedExclusions={includedExclusionTags}
+            onClickSelected={selectItem}
+            onClickExcluded={excludeItem}
+            onClickIncludedExclusion={excludeItem}
             onClear={() => {
               onSelectionChange && onSelectionChange([])
-              onExclusionChange && onExclusionChange([])
+              onExclusionChange && onExclusionChange(tags?.filter((t) => t.excludeByDefault) ?? [])
             }}
           />
         </Box>

--- a/src/renderer/src/Common/Components/TagSelector/TagSelector.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagSelector.tsx
@@ -33,7 +33,7 @@ export function TagSelector({
   const { collapsedGroups, toggleGroupCollapse, expandAll, collapseAll } = useGroupCollapse()
   const { groups, reload, tags } = useTagGroups()
 
-  const { selectItem, itemIsSelected } = useMultiSelection(
+  const { selectItem: toggleSelection, itemIsSelected } = useMultiSelection(
     tags ?? [],
     selection ?? [],
     (s) => onSelectionChange && onSelectionChange(s),
@@ -41,7 +41,7 @@ export function TagSelector({
     { toggleMode: true }
   )
 
-  const { selectItem: excludeItem, itemIsSelected: itemIsExcluded } = useMultiSelection(
+  const { selectItem: toggleExclusion, itemIsSelected: itemIsExcluded } = useMultiSelection(
     tags ?? [],
     exclusion ?? [],
     (s) => onExclusionChange && onExclusionChange(s),
@@ -97,15 +97,15 @@ export function TagSelector({
           collapsedGroups={collapsedGroups}
           onToggleCollapse={toggleGroupCollapse}
           onSelect={(t) => {
-            selectItem(t)
+            toggleSelection(t)
             if (itemIsExcluded(t)) {
-              excludeItem(t)
+              toggleExclusion(t)
             }
           }}
           onExclude={(t) => {
-            excludeItem(t)
+            toggleExclusion(t)
             if (itemIsSelected(t)) {
-              selectItem(t)
+              toggleSelection(t)
             }
           }}
         />
@@ -135,9 +135,9 @@ export function TagSelector({
             selection={selection}
             exclusion={explicitlyExcludedTags}
             includedExclusions={includedExclusionTags}
-            onClickSelected={selectItem}
-            onClickExcluded={excludeItem}
-            onClickIncludedExclusion={excludeItem}
+            onClickSelected={toggleSelection}
+            onClickExcluded={toggleExclusion}
+            onClickIncludedExclusion={toggleExclusion}
             onClear={() => {
               onSelectionChange && onSelectionChange([])
               onExclusionChange && onExclusionChange(tags?.filter((t) => t.excludeByDefault) ?? [])

--- a/src/renderer/src/EntityProviders/TagProvider.tsx
+++ b/src/renderer/src/EntityProviders/TagProvider.tsx
@@ -20,10 +20,6 @@ export function TagProvider({ children }: TagProviderProps) {
 
   const tags = useMemo(() => groups?.map((g) => g.tags ?? []).flat(), [groups])
 
-  if (isLoading) {
-    return <CircularProgress />
-  }
-
   return (
     <TagContext.Provider value={{ groups, tags, isLoading, reload }}>
       {children}

--- a/src/renderer/src/EntityProviders/TagProvider.tsx
+++ b/src/renderer/src/EntityProviders/TagProvider.tsx
@@ -6,7 +6,7 @@ interface TagData {
   groups?: Impart.TagGroup[]
   tags?: Impart.Tag[]
   isLoading: boolean
-  reload: () => void
+  reload: () => Promise<void>
 }
 
 const TagContext = createContext<TagData | null>(null)

--- a/src/renderer/src/EntityProviders/TagProvider.tsx
+++ b/src/renderer/src/EntityProviders/TagProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo } from 'react'
 import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import { CircularProgress } from '@mui/material'
 
 interface TagData {
   groups?: Impart.TagGroup[]
@@ -18,6 +19,10 @@ export function TagProvider({ children }: TagProviderProps) {
   const { data: groups, isLoading, reload } = useImpartIpcData(() => window.tagApi.getGroups(), [])
 
   const tags = useMemo(() => groups?.map((g) => g.tags ?? []).flat(), [groups])
+
+  if (isLoading) {
+    return <CircularProgress />
+  }
 
   return (
     <TagContext.Provider value={{ groups, tags, isLoading, reload }}>

--- a/src/renderer/src/EntityProviders/TaggableProvider.tsx
+++ b/src/renderer/src/EntityProviders/TaggableProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { usePartialState } from '@renderer/Common/Hooks/usePartialState'
 import { useTaskStatus } from '@renderer/TaskStatusProvider'
 import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
@@ -25,17 +25,27 @@ const DEFAULT_PRIVATE_KEY = 'defaultPrivate'
 
 export function TaggableProvider({ children }: TaggableProviderProps) {
   const { isTaskRunning } = useTaskStatus()
-  const { tags } = useTagGroups()
+  const { tags, isLoading: tagsAreLoading } = useTagGroups()
 
   const [stackTrail, setStackTrail] = useState<Impart.TaggableStack[]>([])
   const [fetchOptions, setFetchOptions] = usePartialState<Impart.FetchTaggablesOptions>(
     () =>
       ({
         order: (localStorage.getItem(DEFAULT_ORDER_KEY) as 'alpha' | 'date' | null) ?? 'alpha',
-        allowPrivate: (localStorage.getItem(DEFAULT_PRIVATE_KEY) as boolean | null) ?? true,
-        excludedTagIds: tags?.filter((t) => t.excludeByDefault).map((t) => t.id)
+        allowPrivate: (localStorage.getItem(DEFAULT_PRIVATE_KEY) as boolean | null) ?? true
       }) satisfies Impart.FetchTaggablesOptions
   )
+
+  const tagsLoadedRef = useRef(false)
+
+  useEffect(() => {
+    if (!tagsAreLoading && !tagsLoadedRef.current) {
+      setFetchOptions({
+        excludedTagIds: tags?.filter((t) => t.excludeByDefault).map((t) => t.id)
+      })
+      tagsLoadedRef.current = true
+    }
+  }, [tagsAreLoading, tags])
 
   const updateStackTrail = useCallback((stack: Impart.TaggableStack[]) => {
     setStackTrail(stack)

--- a/src/renderer/src/EntityProviders/TaggableProvider.tsx
+++ b/src/renderer/src/EntityProviders/TaggableProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 import { usePartialState } from '@renderer/Common/Hooks/usePartialState'
 import { useTaskStatus } from '@renderer/TaskStatusProvider'
 import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import { useTagGroups } from './TagProvider'
 
 interface TaggableData {
   taggables: Impart.Taggable[]
@@ -24,13 +25,15 @@ const DEFAULT_PRIVATE_KEY = 'defaultPrivate'
 
 export function TaggableProvider({ children }: TaggableProviderProps) {
   const { isTaskRunning } = useTaskStatus()
+  const { tags } = useTagGroups()
 
   const [stackTrail, setStackTrail] = useState<Impart.TaggableStack[]>([])
   const [fetchOptions, setFetchOptions] = usePartialState<Impart.FetchTaggablesOptions>(
     () =>
       ({
         order: (localStorage.getItem(DEFAULT_ORDER_KEY) as 'alpha' | 'date' | null) ?? 'alpha',
-        allowPrivate: (localStorage.getItem(DEFAULT_PRIVATE_KEY) as boolean | null) ?? true
+        allowPrivate: (localStorage.getItem(DEFAULT_PRIVATE_KEY) as boolean | null) ?? true,
+        excludedTagIds: tags?.filter((t) => t.excludeByDefault).map((t) => t.id)
       }) satisfies Impart.FetchTaggablesOptions
   )
 

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -17,8 +17,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <NotificationProvider>
       <TaskStatusProvider>
         <DirectoryProvider>
-          <TaggableProvider>
-            <TagProvider>
+          <TagProvider>
+            <TaggableProvider>
               <ThemeProvider theme={theme}>
                 <CssBaseline />
                 <ActiveContextMenuProvider>
@@ -27,8 +27,8 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
                   </ConfirmationDialogProvider>
                 </ActiveContextMenuProvider>
               </ThemeProvider>
-            </TagProvider>
-          </TaggableProvider>
+            </TaggableProvider>
+          </TagProvider>
         </DirectoryProvider>
       </TaskStatusProvider>
     </NotificationProvider>


### PR DESCRIPTION
Added a new `excludeByDefault` flag to tags, which can be toggled in the Tag context menu. Enabling this flag makes it so that tags are automatically excluded from the search, and their exclusion won't show the "Active Tags" display on the tag selector. Additionally, hitting the "Clear All" button resets the tag to excluded.

<img width="421" height="385" alt="image" src="https://github.com/user-attachments/assets/bfa3c4e5-effb-46be-9cf8-5fda6c923f05" />

---

Additionally, the "Active Tag" section has been updated to be a little clearer on what state a given tag is in (now that there are technically three states)

<img width="464" height="283" alt="image" src="https://github.com/user-attachments/assets/48bd39e4-29de-4902-8da1-1daef4a6ab42" />
