### PR TITLE
Apply source tags to image on association

### DIFF
--- a/src/main/api/commonApi.ts
+++ b/src/main/api/commonApi.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron'
 import { store } from '../config'
+import { handleError } from '../common/handleError'
 
 //It turns out according to the electron-store docs (https://github.com/sindresorhus/electron-store?tab=readme-ov-file#how-do-i-get-store-values-in-the-renderer-process-when-my-store-was-initialized-in-the-main-process)
 // even though the store should work in the renderer, you can't actually use it
@@ -8,11 +9,15 @@ import { store } from '../config'
 // a getter and setter for each config value, but I can already tell that's gonna be
 // a massive headache in the future
 export function setupCommonApi() {
-  ipcMain.handle('common/getConfigItem', async (_e, key: string) => ({
-    //We wrap the result with an object so that it plays nice with
-    // useImpartIpcData() in the renderer
-    result: store.get(key)
-  }))
+  ipcMain.handle('common/getConfigItem', async (_e, key: string) =>
+    handleError(() => ({
+      //We wrap the result with an object so that it plays nice with
+      // useImpartIpcData() in the renderer
+      result: store.get(key)
+    }))
+  )
 
-  ipcMain.on('common/setConfigItem', async (_e, key: string, value: any) => store.set(key, value))
+  ipcMain.on('common/setConfigItem', async (_e, key: string, value: any) =>
+    handleError(() => store.set(key, value))
+  )
 }

--- a/src/main/common/handleError.ts
+++ b/src/main/common/handleError.ts
@@ -4,7 +4,7 @@ export interface ImpartError {
   name?: string
 }
 
-export async function handleError<T>(func: () => Promise<T>): Promise<T | ImpartError> {
+export async function handleError<T>(func: () => T | Promise<T>): Promise<T | ImpartError> {
   try {
     return await func()
   } catch (e) {

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -9,6 +9,7 @@ interface Config {
   'window.maximized': boolean
   previousVersion: string
   autoUpdatingEnabled: boolean
+  applyTagsOnSourceAssociation: boolean
 }
 
 const schema: Schema<Config> = {
@@ -19,6 +20,9 @@ const schema: Schema<Config> = {
   'window.maximized': {},
   previousVersion: {},
   autoUpdatingEnabled: {
+    default: true
+  },
+  applyTagsOnSourceAssociation: {
     default: true
   }
 }

--- a/src/main/indexables/indexingManager.ts
+++ b/src/main/indexables/indexingManager.ts
@@ -14,6 +14,7 @@ import { ImpartTask, TaskType } from '../task/impartTask'
 import { ThumbnailManager } from './thumbnailManager'
 import { zap } from '../common/zap'
 import { TaggingManager } from '../tagging/taggingManager'
+import { store } from '../config'
 
 export namespace IndexingManager {
   let isIndexing = false
@@ -226,6 +227,10 @@ export namespace IndexingManager {
 
       console.log('Associating indexed image with: ', possibleSourceFiles[0].fileIndex.path)
       image.source = possibleSourceFiles[0]
+
+      if (image.tags.length == 0 && store.get('applyTagsOnSourceAssociation')) {
+        image.tags = possibleSourceFiles[0].tags
+      }
 
       await image.save()
     }

--- a/src/main/tagging/taggableManager.ts
+++ b/src/main/tagging/taggableManager.ts
@@ -2,6 +2,7 @@ import { In, SelectQueryBuilder } from 'typeorm'
 import { Taggable } from '../database/entities/Taggable'
 import { TaggableImage } from '../database/entities/TaggableImage'
 import { TaggableFile } from '../database/entities/TaggableFile'
+import { store } from '../config'
 
 export interface FetchTaggablesOptions {
   tagIds?: number[]
@@ -155,6 +156,11 @@ export namespace TaggableManager {
     await Promise.all(
       images.map(async (i) => {
         i.source = file
+
+        if (i.tags.length == 0 && store.get('applyTagsOnSourceAssociation')) {
+          i.tags = file.tags
+        }
+
         await i.save()
       })
     )

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -114,8 +114,11 @@ declare global {
     commonApi: {
       getConfigItem: <Key extends keyof ConfigItems>(
         key: Key
-      ) => Promise<{ result: Impart.ConfigItems[Key] }>
-      setConfigItem: <Key extends keyof ConfigItems>(key: Key, value: ConfigItems[Key]) => void
+      ) => Result<{ result: Impart.ConfigItems[Key] }>
+      setConfigItem: <Key extends keyof ConfigItems>(
+        key: Key,
+        value: ConfigItems[Key]
+      ) => Result<void>
     }
 
     fileApi: {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -3,13 +3,14 @@ import { ElectronAPI } from '@electron-toolkit/preload'
 type CallbackFunc<Payload> = (callback: (values: Payload) => void) => () => void
 type Result<Payload> = Promise<Payload | Impart.Error>
 
-interface ConfigItems {
-  previousVersion: string
-  autoUpdatingEnabled: boolean
-}
-
 declare global {
   namespace Impart {
+    interface ConfigItems {
+      previousVersion: string
+      autoUpdatingEnabled: boolean
+      applyTagsOnSourceAssociation: boolean
+    }
+
     interface Dimensions {
       width: number
       height: number
@@ -116,7 +117,7 @@ declare global {
     commonApi: {
       getConfigItem: <Key extends keyof ConfigItems>(
         key: Key
-      ) => Promise<{ result: ConfigItems[Key] }>
+      ) => Promise<{ result: Impart.ConfigItems[Key] }>
       setConfigItem: <Key extends keyof ConfigItems>(key: Key, value: ConfigItems[Key]) => void
     }
 

--- a/src/renderer/src/Settings/Settings.tsx
+++ b/src/renderer/src/Settings/Settings.tsx
@@ -10,8 +10,10 @@ import InfoIcon from '@mui/icons-material/InfoRounded'
 import { About } from './About/About'
 import { Updates } from './Updates'
 import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt'
+import { Tagging } from './Tagging'
+import LabelIcon from '@mui/icons-material/Label'
 
-type SettingsType = 'updates' | 'directories' | 'hiddenItems' | 'about'
+type SettingsType = 'updates' | 'directories' | 'hiddenItems' | 'about' | 'tagging'
 
 export interface SettingsProps {
   onClose?: () => void
@@ -20,10 +22,6 @@ export interface SettingsProps {
 
 export function Settings({ onClose, onShowPatchNotes }: SettingsProps) {
   const [selectedTab, setSelectedTab] = useState<SettingsType>('directories')
-
-  const { isTaskRunning } = useTaskStatus()
-
-  const test = false
 
   return (
     <Stack height="100%" justifyContent="center">
@@ -51,9 +49,12 @@ export function Settings({ onClose, onShowPatchNotes }: SettingsProps) {
                 sx={{
                   marginRight: '-2px'
                 }}
-                TabIndicatorProps={{ sx: (theme) => ({ bgcolor: theme.palette.background.paper }) }}
+                slotProps={{
+                  indicator: { sx: (theme) => ({ bgcolor: theme.palette.background.paper }) }
+                }}
               >
                 <Tab label="Directories" value="directories" icon={<FolderIcon />} />
+                <Tab label="Tagging" value="tagging" icon={<LabelIcon />} />
                 <Tab label="Hidden Items" value="hiddenItems" icon={<HideImageIcon />} />
                 <Tab label="Updates" value="updates" icon={<SystemUpdateAltIcon />} />
                 <Tab label="About" value="about" icon={<InfoIcon />} />
@@ -61,6 +62,7 @@ export function Settings({ onClose, onShowPatchNotes }: SettingsProps) {
             </Stack>
             <Box flex={1} p={1} pr={8} height="100%" sx={{ overflowY: 'scroll' }}>
               {selectedTab === 'directories' && <IndexedDirectoriesSettings />}
+              {selectedTab === 'tagging' && <Tagging />}
               {selectedTab === 'hiddenItems' && <HiddenItems />}
               {selectedTab === 'updates' && <Updates onShowPatchNotes={onShowPatchNotes} />}
               {selectedTab === 'about' && <About />}

--- a/src/renderer/src/Settings/Tagging.tsx
+++ b/src/renderer/src/Settings/Tagging.tsx
@@ -1,0 +1,21 @@
+import { Box, Stack, Typography } from '@mui/material'
+import { ToggleSetting } from './ToggleSetting'
+
+export interface TaggingProps {}
+
+export function Tagging({}: TaggingProps) {
+  return (
+    <Box>
+      <Stack mt={1} mb={2} direction="row" gap={2} alignItems="center">
+        <Typography variant="h3">Tagging</Typography>
+      </Stack>
+      <ToggleSetting
+        storeKey="applyTagsOnSourceAssociation"
+        title="Apply source tags to image on association"
+        subtitle={
+          'Copies all tags from the source file to the image file upon association. Only occurs if the image has no tags.'
+        }
+      />
+    </Box>
+  )
+}

--- a/src/renderer/src/Settings/ToggleSetting.tsx
+++ b/src/renderer/src/Settings/ToggleSetting.tsx
@@ -1,5 +1,5 @@
 import { Stack, Box, Switch, Skeleton, Typography } from '@mui/material'
-import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import { useImpartIpcCall, useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
 import React, { useEffect, useState } from 'react'
 
 //Acquired from https://stackoverflow.com/questions/50851263/how-do-i-require-a-keyof-to-be-for-a-property-of-a-specific-type
@@ -14,6 +14,8 @@ export interface ToggleSettingProps {
 export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps) {
   const [checked, setChecked] = useState(true)
 
+  const { callIpc: setConfigItem } = useImpartIpcCall(window.commonApi.setConfigItem, [])
+
   const { data: actualSettingValue, isLoading } = useImpartIpcData(
     () => window.commonApi.getConfigItem(storeKey),
     [storeKey]
@@ -27,7 +29,7 @@ export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps)
 
   const update = (checked: boolean) => {
     setChecked(checked)
-    window.commonApi.setConfigItem(storeKey, checked)
+    setConfigItem(storeKey, checked)
   }
 
   return (

--- a/src/renderer/src/Settings/ToggleSetting.tsx
+++ b/src/renderer/src/Settings/ToggleSetting.tsx
@@ -1,0 +1,47 @@
+import { Stack, Box, Switch, Skeleton, Typography } from '@mui/material'
+import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import React, { useEffect, useState } from 'react'
+
+//Acquired from https://stackoverflow.com/questions/50851263/how-do-i-require-a-keyof-to-be-for-a-property-of-a-specific-type
+type BooleanKeys<T> = { [k in keyof T]: T[k] extends boolean ? k : never }[keyof T]
+
+export interface ToggleSettingProps {
+  storeKey: BooleanKeys<Impart.ConfigItems>
+  title: string
+  subtitle?: React.ReactNode
+}
+
+export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps) {
+  const [checked, setChecked] = useState(true)
+
+  const { data: actualSettingValue, isLoading } = useImpartIpcData(
+    () => window.commonApi.getConfigItem(storeKey),
+    [storeKey]
+  )
+
+  useEffect(() => {
+    if (actualSettingValue) {
+      setChecked(actualSettingValue?.result)
+    }
+  }, [actualSettingValue])
+
+  const update = (checked: boolean) => {
+    setChecked(checked)
+    window.commonApi.setConfigItem(storeKey, checked)
+  }
+
+  return (
+    <Stack direction="row" alignItems={'center'}>
+      <Box width={100} textAlign="center">
+        {!isLoading && (
+          <Switch checked={checked} onChange={(e) => update(e.currentTarget.checked)} />
+        )}
+        {isLoading && <Skeleton />}
+      </Box>
+      <Box flex={1}>
+        <Typography fontWeight="bold">{title}</Typography>
+        <Typography variant="body2">{subtitle}</Typography>
+      </Box>
+    </Stack>
+  )
+}

--- a/src/renderer/src/Settings/Updates.tsx
+++ b/src/renderer/src/Settings/Updates.tsx
@@ -1,31 +1,12 @@
-import { Box, Button, CircularProgress, Skeleton, Stack, Switch, Typography } from '@mui/material'
-import React, { useEffect, useState } from 'react'
+import { Box, Button, Stack, Typography } from '@mui/material'
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted'
-import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import { ToggleSetting } from './ToggleSetting'
 
 export interface UpdatesProps {
   onShowPatchNotes?: () => void
 }
 
 export function Updates({ onShowPatchNotes }: UpdatesProps) {
-  const [autoUpdate, setAutoUpdate] = useState(true)
-
-  const { data: autoUpdateValue, isLoading } = useImpartIpcData(
-    () => window.commonApi.getConfigItem('autoUpdatingEnabled'),
-    []
-  )
-
-  useEffect(() => {
-    if (autoUpdateValue) {
-      setAutoUpdate(autoUpdateValue?.result)
-    }
-  }, [autoUpdateValue])
-
-  const update = (checked: boolean) => {
-    setAutoUpdate(checked)
-    window.commonApi.setConfigItem('autoUpdatingEnabled', checked)
-  }
-
   return (
     <Box>
       <Stack mt={1} mb={2} direction="row" gap={2} alignItems="center">
@@ -38,16 +19,11 @@ export function Updates({ onShowPatchNotes }: UpdatesProps) {
           Show Patch Notes
         </Button>
       </Stack>
-      <Stack direction="row" alignItems={'center'}>
-        <Box width={100} textAlign="center">
-          {!isLoading && (
-            <Switch checked={autoUpdate} onChange={(e) => update(e.currentTarget.checked)} />
-          )}
-          {isLoading && <Skeleton />}
-        </Box>
-        <Box flex={1}>
-          <Typography fontWeight="bold">Enable Auto Updating</Typography>
-          <Typography variant="body2">
+      <ToggleSetting
+        storeKey="autoUpdatingEnabled"
+        title="Enable Auto Updating"
+        subtitle={
+          <>
             Auto-updating takes place whenever the app starts up. If disabled, updates can always be
             installed the conventional way (downloading them from{' '}
             <a href="https://arastryx.itch.io/impart" target="_blank">
@@ -61,9 +37,9 @@ export function Updates({ onShowPatchNotes }: UpdatesProps) {
             <Typography variant="caption" component="span" color="primary.light">
               TODO: Implement fancy "Check For Updates" button and so on
             </Typography>
-          </Typography>
-        </Box>
-      </Stack>
+          </>
+        }
+      />
     </Box>
   )
 }


### PR DESCRIPTION
Resolves #15 

When associating a source file with an image file, the source tags are now applied to the image file. Added a setting to disable this feature as well