### PR TITLE
Delete Group With Active Tags

### DIFF
--- a/src/main/tagging/tagManager.ts
+++ b/src/main/tagging/tagManager.ts
@@ -1,4 +1,5 @@
 import { arrayMoveImmutable } from '../common/arrayMove'
+import { AppDataSource } from '../database/database'
 import { Tag } from '../database/entities/Tag'
 import { TagGroup } from '../database/entities/TagGroup'
 
@@ -72,7 +73,12 @@ export namespace TagManager {
 
   export async function deleteGroup(id: number) {
     const groupEntity = await TagGroup.findOneByOrFail({ id })
-    await groupEntity.remove()
+
+    await AppDataSource.transaction(async (manager) => {
+      await Promise.all(groupEntity.tags.map((t) => manager.remove(t)))
+      await manager.remove(groupEntity)
+    })
+
     return true
   }
 


### PR DESCRIPTION
Fixes #23 

Fixed not being able to delete a tag group if any of the tags within it were assigned to a taggable. There's probably a way to fix this with cascading deletion but typeorm makes it weird so I'm just gonna fix it manually. Also, this is apparently the first time I set up a transaction in the app? Weird!