### PR TITLE
Show Patch Notes Setting

### DIFF
--- a/src/main/api/commonApi.ts
+++ b/src/main/api/commonApi.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import { store } from '../config'
 import { handleError } from '../common/handleError'
+import { impartApp } from '..'
 
 //It turns out according to the electron-store docs (https://github.com/sindresorhus/electron-store?tab=readme-ov-file#how-do-i-get-store-values-in-the-renderer-process-when-my-store-was-initialized-in-the-main-process)
 // even though the store should work in the renderer, you can't actually use it
@@ -18,6 +19,9 @@ export function setupCommonApi() {
   )
 
   ipcMain.on('common/setConfigItem', async (_e, key: string, value: any) =>
-    handleError(() => store.set(key, value))
+    handleError(() => {
+      store.set(key, value)
+      impartApp.mainWindow?.webContents.send('common/configUpdated', { key, value })
+    })
   )
 }

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -10,6 +10,7 @@ interface Config {
   previousVersion: string
   autoUpdatingEnabled: boolean
   applyTagsOnSourceAssociation: boolean
+  showPatchNotesOnUpdate: boolean
 }
 
 const schema: Schema<Config> = {
@@ -23,6 +24,9 @@ const schema: Schema<Config> = {
     default: true
   },
   applyTagsOnSourceAssociation: {
+    default: true
+  },
+  showPatchNotesOnUpdate: {
     default: true
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,6 +9,7 @@ declare global {
       previousVersion: string
       autoUpdatingEnabled: boolean
       applyTagsOnSourceAssociation: boolean
+      showPatchNotesOnUpdate: boolean
     }
 
     interface Dimensions {
@@ -112,13 +113,14 @@ declare global {
     electron: ElectronAPI
 
     commonApi: {
-      getConfigItem: <Key extends keyof ConfigItems>(
+      getConfigItem: <Key extends keyof Impart.ConfigItems>(
         key: Key
       ) => Result<{ result: Impart.ConfigItems[Key] }>
-      setConfigItem: <Key extends keyof ConfigItems>(
+      setConfigItem: <Key extends keyof Impart.ConfigItems>(
         key: Key,
-        value: ConfigItems[Key]
+        value: Impart.ConfigItems[Key]
       ) => Result<void>
+      onConfigUpdated: CallbackFunc<{ key: string; value: any }>
     }
 
     fileApi: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,7 +21,8 @@ function generateCallback(channel: string) {
 
 contextBridge.exposeInMainWorld('commonApi', {
   getConfigItem: generateEndpoint('common/getConfigItem'),
-  setConfigItem: generateCommand('common/setConfigItem')
+  setConfigItem: generateCommand('common/setConfigItem'),
+  onConfigUpdated: generateCallback('common/configUpdated')
 })
 
 contextBridge.exposeInMainWorld('fileApi', {

--- a/src/renderer/src/Impart.tsx
+++ b/src/renderer/src/Impart.tsx
@@ -27,8 +27,6 @@ export function Impart({}: ImpartProps) {
   const [currentModal, setCurrentModal] = useState<ImpartModal | null>(null)
   const [selection, setSelection] = useState<Impart.Taggable[]>([])
 
-  useHotkeys('escape', () => setCurrentModal(null))
-
   const { reload: fetchTaggables } = useTaggables()
 
   const { show, setShow } = useShowPatchNotes()

--- a/src/renderer/src/PatchNotes/PatchNotes.tsx
+++ b/src/renderer/src/PatchNotes/PatchNotes.tsx
@@ -1,8 +1,9 @@
-import { Dialog, DialogContent, DialogTitle, Divider, Stack } from '@mui/material'
+import { Dialog, DialogContent, DialogTitle, Divider, Stack, Typography } from '@mui/material'
 import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
 import React, { useEffect, useState } from 'react'
 import { Patch1_2_0 } from './Patches/Patch1_2_0'
 import { PatchOld } from './Patches/PatchOld'
+import { ToggleSetting } from '@renderer/Settings/ToggleSetting'
 
 export interface PatchNotesProps {
   show: boolean
@@ -12,7 +13,12 @@ export interface PatchNotesProps {
 export function PatchNotes({ show, onClose }: PatchNotesProps) {
   return (
     <Dialog open={show} onClose={onClose} maxWidth="xl" fullWidth>
-      <DialogTitle variant="h2">Patch Notes</DialogTitle>
+      <DialogTitle>
+        <Stack direction="row" justifyContent={'space-between'} alignItems={'flex-start'}>
+          <Typography variant="h2">Patch Notes</Typography>
+          <ToggleSetting storeKey="showPatchNotesOnUpdate" title="Show on update" small />
+        </Stack>
+      </DialogTitle>
       <DialogContent>
         <Stack gap={5} divider={<Divider />}>
           <Patch1_2_0 />

--- a/src/renderer/src/PatchNotes/useShowPatchNotes.ts
+++ b/src/renderer/src/PatchNotes/useShowPatchNotes.ts
@@ -18,12 +18,12 @@ export function useShowPatchNotes() {
     if (
       !loadingVersion &&
       !loadingShowPatchNotes &&
-      showPatchNotesOnUpdate &&
+      showPatchNotesOnUpdate?.result &&
       previousVersion?.result != import.meta.env.PACKAGE_VERSION
     ) {
       setShow(true)
     }
-  }, [previousVersion])
+  }, [previousVersion, loadingVersion, showPatchNotesOnUpdate, loadingShowPatchNotes])
 
   return { show, setShow }
 }

--- a/src/renderer/src/PatchNotes/useShowPatchNotes.ts
+++ b/src/renderer/src/PatchNotes/useShowPatchNotes.ts
@@ -4,13 +4,23 @@ import { useState, useEffect } from 'react'
 export function useShowPatchNotes() {
   const [show, setShow] = useState(false)
 
-  const { data: previousVersion, isLoading } = useImpartIpcData(
+  const { data: previousVersion, isLoading: loadingVersion } = useImpartIpcData(
     () => window.commonApi.getConfigItem('previousVersion'),
     []
   )
 
+  const { data: showPatchNotesOnUpdate, isLoading: loadingShowPatchNotes } = useImpartIpcData(
+    () => window.commonApi.getConfigItem('showPatchNotesOnUpdate'),
+    []
+  )
+
   useEffect(() => {
-    if (!isLoading && previousVersion?.result != import.meta.env.PACKAGE_VERSION) {
+    if (
+      !loadingVersion &&
+      !loadingShowPatchNotes &&
+      showPatchNotesOnUpdate &&
+      previousVersion?.result != import.meta.env.PACKAGE_VERSION
+    ) {
       setShow(true)
     }
   }, [previousVersion])

--- a/src/renderer/src/Settings/ToggleSetting.tsx
+++ b/src/renderer/src/Settings/ToggleSetting.tsx
@@ -9,9 +9,10 @@ export interface ToggleSettingProps {
   storeKey: BooleanKeys<Impart.ConfigItems>
   title: string
   subtitle?: React.ReactNode
+  small?: boolean
 }
 
-export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps) {
+export function ToggleSetting({ storeKey, title, subtitle, small }: ToggleSettingProps) {
   const [checked, setChecked] = useState(true)
 
   const { callIpc: setConfigItem } = useImpartIpcCall(window.commonApi.setConfigItem, [])
@@ -27,6 +28,14 @@ export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps)
     }
   }, [actualSettingValue])
 
+  useEffect(() => {
+    return window.commonApi.onConfigUpdated(({ key, value }) => {
+      if (key === storeKey) {
+        setChecked(value)
+      }
+    })
+  }, [])
+
   const update = (checked: boolean) => {
     setChecked(checked)
     setConfigItem(storeKey, checked)
@@ -34,14 +43,20 @@ export function ToggleSetting({ storeKey, title, subtitle }: ToggleSettingProps)
 
   return (
     <Stack direction="row" alignItems={'center'}>
-      <Box width={100} textAlign="center">
+      <Box width={small ? 60 : 80} textAlign="center">
         {!isLoading && (
-          <Switch checked={checked} onChange={(e) => update(e.currentTarget.checked)} />
+          <Switch
+            checked={checked}
+            onChange={(e) => update(e.currentTarget.checked)}
+            size={small ? 'small' : 'medium'}
+          />
         )}
         {isLoading && <Skeleton />}
       </Box>
       <Box flex={1}>
-        <Typography fontWeight="bold">{title}</Typography>
+        <Typography variant={small ? 'body2' : 'body1'} fontWeight="bold">
+          {title}
+        </Typography>
         <Typography variant="body2">{subtitle}</Typography>
       </Box>
     </Stack>

--- a/src/renderer/src/Settings/Updates.tsx
+++ b/src/renderer/src/Settings/Updates.tsx
@@ -19,27 +19,30 @@ export function Updates({ onShowPatchNotes }: UpdatesProps) {
           Show Patch Notes
         </Button>
       </Stack>
-      <ToggleSetting
-        storeKey="autoUpdatingEnabled"
-        title="Enable Auto Updating"
-        subtitle={
-          <>
-            Auto-updating takes place whenever the app starts up. If disabled, updates can always be
-            installed the conventional way (downloading them from{' '}
-            <a href="https://arastryx.itch.io/impart" target="_blank">
-              Itch.io
-            </a>{' '}
-            or{' '}
-            <a href="https://github.com/Arastryx/impart/releases" target="_blank">
-              GitHub
-            </a>
-            ).{' '}
-            <Typography variant="caption" component="span" color="primary.light">
-              TODO: Implement fancy "Check For Updates" button and so on
-            </Typography>
-          </>
-        }
-      />
+      <Stack gap={2}>
+        <ToggleSetting
+          storeKey="autoUpdatingEnabled"
+          title="Enable Auto Updating"
+          subtitle={
+            <>
+              Auto-updating takes place whenever the app starts up. If disabled, updates can always
+              be installed the conventional way (downloading them from{' '}
+              <a href="https://arastryx.itch.io/impart" target="_blank">
+                Itch.io
+              </a>{' '}
+              or{' '}
+              <a href="https://github.com/Arastryx/impart/releases" target="_blank">
+                GitHub
+              </a>
+              ).{' '}
+              <Typography variant="caption" component="span" color="primary.light">
+                TODO: Implement fancy "Check For Updates" button and so on
+              </Typography>
+            </>
+          }
+        />
+        <ToggleSetting storeKey="showPatchNotesOnUpdate" title="Show patch notes on update" />
+      </Stack>
     </Box>
   )
 }


### PR DESCRIPTION
Resolves #36 

Added a setting to disable showing patch notes on update

<img width="733" height="291" alt="image" src="https://github.com/user-attachments/assets/1d6cf16e-5b51-4f5a-b2a4-3b2857b202bb" />

Also added a callback for whenever the store gets updated. Only used right now by the new setting since it can be set in multiple places, but it might be handy in the future at some point.