### PR TITLE
Source Filter + Detach Source File

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typewatch:node": "tsc --noEmit -w -p tsconfig.node.json --composite false",
     "typewatch:web": "tsc --noEmit -w -p tsconfig.web.json --composite false",
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev --watch",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/src/main/api/taggableApi.ts
+++ b/src/main/api/taggableApi.ts
@@ -26,5 +26,11 @@ export function setupTaggableApi() {
     (e, ...params: Parameters<typeof TaggableManager.associateImageWithFile>) =>
       handleError(() => TaggableManager.associateImageWithFile(...params))
   )
+
+  ipcMain.handle(
+    'taggable/detachSourceFile',
+    (e, ...params: Parameters<typeof TaggableManager.detachSourceFile>) =>
+      handleError(() => TaggableManager.detachSourceFile(...params))
+  )
 }
 

--- a/src/main/database/entities/TaggableImage.ts
+++ b/src/main/database/entities/TaggableImage.ts
@@ -26,7 +26,7 @@ export class TaggableImage extends Taggable {
     eager: true,
     onDelete: 'SET NULL'
   })
-  source?: TaggableFile
+  source?: TaggableFile | null
 
   @OneToOne(() => Thumbnail, { nullable: true, cascade: true, onDelete: 'SET NULL' })
   @JoinColumn()
@@ -43,3 +43,4 @@ export class TaggableImage extends Taggable {
 export function isTaggableImage(t: Taggable): t is TaggableImage {
   return (t as TaggableImage).dimensions != null
 }
+

--- a/src/main/tagging/taggableManager.ts
+++ b/src/main/tagging/taggableManager.ts
@@ -4,6 +4,8 @@ import { TaggableImage } from '../database/entities/TaggableImage'
 import { TaggableFile } from '../database/entities/TaggableFile'
 import { store } from '../config'
 
+type SourceFileFilter = 'only' | 'all' | 'unassociated' | 'onlyUnassociated' | 'none'
+
 export interface FetchTaggablesOptions {
   tagIds?: number[]
   excludedTagIds?: number[]
@@ -13,55 +15,64 @@ export interface FetchTaggablesOptions {
   directories?: string[]
   stackId?: number
   onlyHidden?: boolean
-  onlyFiles?: boolean
   allowPrivate?: boolean
+  sourceFiles?: SourceFileFilter
 }
 
 export namespace TaggableManager {
   export async function getTaggables(options?: FetchTaggablesOptions) {
-    let query = (options?.onlyFiles ? TaggableFile : Taggable)
+    let query = (
+      options?.sourceFiles == 'only' || options?.sourceFiles == 'onlyUnassociated'
+        ? TaggableFile
+        : options?.sourceFiles == 'none'
+          ? TaggableImage
+          : Taggable
+    )
       .createQueryBuilder('files')
       .setFindOptions({
         loadEagerRelations: true
       })
 
-    if (options) {
-      const { tagIds, order, search, year, excludedTagIds, directories, allowPrivate } = options
-      if (tagIds && tagIds.length > 0) {
-        applyTags(query, tagIds)
-      }
+    if (options?.tagIds && options.tagIds.length > 0) {
+      applyTags(query, options.tagIds)
+    }
 
-      if (excludedTagIds && excludedTagIds.length > 0) {
-        applyExcludedTags(query, excludedTagIds)
-      }
+    if (options?.excludedTagIds && options.excludedTagIds.length > 0) {
+      applyExcludedTags(query, options.excludedTagIds)
+    }
 
-      if (order) {
-        applyOrder(query, order)
-      }
+    if (options?.order) {
+      applyOrder(query, options.order)
+    }
 
-      if (search && search != '') {
-        applySearch(query, search)
-      }
+    if (options?.search && options.search != '') {
+      applySearch(query, options.search)
+    }
 
-      if (year) {
-        query.andWhere("strftime('%Y', files.dateModified) = :year", { year: year.toString() })
-      }
+    if (options?.year) {
+      query.andWhere("strftime('%Y', files.dateModified) = :year", {
+        year: options.year.toString()
+      })
+    }
 
-      if (directories && directories.length > 0) {
-        query.andWhere('files.directory IN (:...directories)', { directories })
-      }
+    if (options?.directories && options.directories.length > 0) {
+      query.andWhere('files.directory IN (:...directories)', { directories: options.directories })
+    }
 
-      if (!allowPrivate) {
-        query.andWhere(
-          `files.id NOT IN (SELECT taggable.id
+    if (!options?.allowPrivate) {
+      query.andWhere(
+        `files.id NOT IN (SELECT taggable.id
             FROM taggable
             INNER JOIN taggable_tags_tag AS relation ON taggable.id = relation.taggableId
             INNER JOIN tag ON relation.tagId = tag.id AND tag.isPrivate = 1)`
-        )
-      }
+      )
     }
 
-    if (!options?.onlyFiles) {
+    if (
+      options?.sourceFiles == null ||
+      options.sourceFiles == 'unassociated' ||
+      options.sourceFiles == 'onlyUnassociated'
+    ) {
       query.leftJoin('files.images', 'associatedImages').andWhere('associatedImages.id IS NULL')
     }
 

--- a/src/main/tagging/taggableManager.ts
+++ b/src/main/tagging/taggableManager.ts
@@ -176,5 +176,16 @@ export namespace TaggableManager {
       })
     )
   }
+
+  export async function detachSourceFile(imageIds: number[]) {
+    const images = await TaggableImage.findBy({ id: In(imageIds) })
+
+    await Promise.all(
+      images.map(async (i) => {
+        i.source = null
+        await i.save()
+      })
+    )
+  }
 }
 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -60,6 +60,8 @@ declare global {
 
     type Taggable = TaggableImage | TaggableFile | TaggableStack
 
+    type SourceFileFilter = 'only' | 'all' | 'unassociated' | 'onlyUnassociated' | 'none'
+
     interface FetchTaggablesOptions {
       tagIds?: number[]
       excludedTagIds?: number[]
@@ -71,6 +73,7 @@ declare global {
       onlyHidden?: boolean
       onlyFiles?: boolean
       allowPrivate?: boolean
+      sourceFiles?: SourceFileFilter
     }
 
     //~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -136,6 +136,7 @@ declare global {
       getAllTaggableYears: () => Result<number[]>
       setHidden: (ids: number[], hidden: boolean) => Result<void>
       associateImageWithFile: (imageIds: number[], fileId: number) => Result<void>
+      detachSourceFile: (imageIds: number[]) => Result<void>
     }
 
     stackApi: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,7 +44,8 @@ contextBridge.exposeInMainWorld('taggableApi', {
   getTaggables: generateEndpoint('taggable/getTaggables'),
   getAllTaggableYears: generateEndpoint('taggable/getAllTaggableYears'),
   setHidden: generateEndpoint('taggable/setHidden'),
-  associateImageWithFile: generateEndpoint('taggable/associateImageWithFile')
+  associateImageWithFile: generateEndpoint('taggable/associateImageWithFile'),
+  detachSourceFile: generateEndpoint('taggable/detachSourceFile')
 })
 
 contextBridge.exposeInMainWorld('stackApi', {

--- a/src/renderer/src/Common/Components/ContextMenu/ContextMenu.tsx
+++ b/src/renderer/src/Common/Components/ContextMenu/ContextMenu.tsx
@@ -69,9 +69,9 @@ export function ContextMenu({ options, render, disabled, ...boxProps }: ContextM
           }) satisfies PopoverVirtualElement
         }
       >
-        <ClickAwayListener onClickAway={() => closeMenu()}>
+        <ClickAwayListener onClickAway={closeMenu}>
           <Paper>
-            <ContextMenuList options={options} />
+            <ContextMenuList options={options} onClose={closeMenu} />
           </Paper>
         </ClickAwayListener>
       </BetterPopper>

--- a/src/renderer/src/Common/Components/ContextMenu/ContextMenuList.tsx
+++ b/src/renderer/src/Common/Components/ContextMenu/ContextMenuList.tsx
@@ -38,9 +38,7 @@ export function ContextMenuList({ options, onClose }: ContextMenuListProps) {
               key={index}
               onClick={(e) => {
                 o.onClick && o.onClick()
-                if (o.isChecked === undefined) {
-                  onClose?.()
-                }
+                onClose?.()
                 e.stopPropagation()
               }}
               disabled={o.disabled}

--- a/src/renderer/src/Common/Components/ContextMenu/ContextMenuList.tsx
+++ b/src/renderer/src/Common/Components/ContextMenu/ContextMenuList.tsx
@@ -38,7 +38,9 @@ export function ContextMenuList({ options, onClose }: ContextMenuListProps) {
               key={index}
               onClick={(e) => {
                 o.onClick && o.onClick()
-                onClose?.()
+                if (o.isChecked === undefined) {
+                  onClose?.()
+                }
                 e.stopPropagation()
               }}
               disabled={o.disabled}

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/GridFilter.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/GridFilter.tsx
@@ -10,10 +10,25 @@ export interface GridFilterProps {
   anchorEl: HTMLDivElement | null
 }
 
+function getSourceFilterLabel(filter: Impart.SourceFileFilter) {
+  switch (filter) {
+    case 'only':
+      return 'Only Non-Image Files'
+    case 'all':
+      return 'Including All Non-Image Files'
+    case 'onlyUnassociated':
+      return 'Only Unassociated Non-Image Files'
+    case 'none':
+      return 'Excluding Non-Image Files'
+  }
+
+  return 'Unkonwn Non-Image File Filter'
+}
+
 export function GridFilter({ anchorEl }: GridFilterProps) {
   const [showFilters, setShowFilters] = useState(false)
   const {
-    fetchOptions: { year, directories },
+    fetchOptions: { year, directories, sourceFiles },
     setFetchOptions
   } = useTaggables()
 
@@ -27,6 +42,13 @@ export function GridFilter({ anchorEl }: GridFilterProps) {
           label={directories.length === 1 ? directories[0] : `${directories.length} Directories`}
           size="small"
           onDelete={() => setFetchOptions({ directories: undefined })}
+        />
+      )}
+      {sourceFiles != undefined && sourceFiles != 'unassociated' && (
+        <Chip
+          label={getSourceFilterLabel(sourceFiles)}
+          size="small"
+          onDelete={() => setFetchOptions({ sourceFiles: undefined })}
         />
       )}
       <IconButton size="small" onClick={() => setShowFilters(true)}>

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/GridFilter.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/GridFilter.tsx
@@ -4,6 +4,7 @@ import { useTaggables } from '@renderer/EntityProviders/TaggableProvider'
 import FilterIcon from '@mui/icons-material/FilterAltRounded'
 import { useState } from 'react'
 import { DirectorySelector } from './DirectorySelector'
+import { SourceVisibilitySelector } from './SourceVisibilitySelector'
 
 export interface GridFilterProps {
   anchorEl: HTMLDivElement | null
@@ -44,9 +45,10 @@ export function GridFilter({ anchorEl }: GridFilterProps) {
           horizontal: 'right'
         }}
       >
-        <Stack p={2} gap={1}>
+        <Stack p={2} gap={1.5}>
           <YearSelector />
           <DirectorySelector />
+          <SourceVisibilitySelector />
         </Stack>
       </Popover>
     </>

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/SourceVisibilitySelector.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/GridActions/SourceVisibilitySelector.tsx
@@ -1,0 +1,25 @@
+import { MenuItem, TextField } from '@mui/material'
+import { useTaggables } from '@renderer/EntityProviders/TaggableProvider'
+import React from 'react'
+
+export interface SourceVisibilitySelectorProps {}
+
+export function SourceVisibilitySelector({}: SourceVisibilitySelectorProps) {
+  const { fetchOptions, setFetchOptions } = useTaggables()
+
+  return (
+    <TextField
+      label="Non-Image Files"
+      select
+      value={fetchOptions.sourceFiles ?? 'unassociated'}
+      onChange={(e) => setFetchOptions({ sourceFiles: e.target.value as Impart.SourceFileFilter })}
+      size="small"
+    >
+      <MenuItem value="only">Only</MenuItem>
+      <MenuItem value="onlyUnassociated">Only Unassociated</MenuItem>
+      <MenuItem value="all">All</MenuItem>
+      <MenuItem value="unassociated">Unassociated</MenuItem>
+      <MenuItem value="none">None</MenuItem>
+    </TextField>
+  )
+}

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
@@ -143,6 +143,7 @@ export function useTaggableContextMenuOptions(
           }
         )
     },
+    'divider',
     {
       icon: <LinkOffIcon />,
       label: 'Detach Source File',
@@ -171,7 +172,6 @@ export function useTaggableContextMenuOptions(
         }
       }
     },
-    'divider',
     {
       icon: <HideImageIcon />,
       label: 'Hide',

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
@@ -146,10 +146,29 @@ export function useTaggableContextMenuOptions(
     {
       icon: <LinkOffIcon />,
       label: 'Detach Source File',
-      hide: !selection.some(isTaggableImage),
+      hide:
+        selection.some((s) => !isTaggableImage(s)) ||
+        selection.filter(isTaggableImage).every((s) => s.source == null),
       onClick: async () => {
-        await detachSourceFile(selection.filter(isTaggableImage).map((s) => s.id))
-        reload()
+        const imagesWithSource = selection.filter(isTaggableImage).filter((s) => s.source != null)
+
+        if (imagesWithSource.length == 1) {
+          await detachSourceFile([imagesWithSource[0].id])
+          reload()
+        } else {
+          confirm(
+            {
+              title: 'Detach Source Files?',
+              body: `This will detach the source files from ${imagesWithSource.length} images`,
+              confirmIcon: <LinkOffIcon />,
+              confirmText: 'Unlink'
+            },
+            async () => {
+              await detachSourceFile(selection.filter(isTaggableImage).map((s) => s.id))
+              reload()
+            }
+          )
+        }
       }
     },
     'divider',

--- a/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
+++ b/src/renderer/src/TaggableBrowser/BrowserPanel/useTaggableContextMenuOptions.tsx
@@ -14,6 +14,7 @@ import CancelIcon from '@mui/icons-material/CancelRounded'
 import DriveFileRenameOutlineIcon from '@mui/icons-material/DriveFileRenameOutlineRounded'
 import AddLinkIcon from '@mui/icons-material/AddLinkRounded'
 import { isTaggableImage, isTaggableStack } from '@renderer/Common/taggable'
+import LinkOffIcon from '@mui/icons-material/LinkOff'
 
 export interface TaggableGridEvents {
   onAssociateWithSource?: (taggables: Impart.TaggableImage[]) => void
@@ -40,6 +41,7 @@ export function useTaggableContextMenuOptions(
   const confirm = useConfirmationDialog()
   const { callIpc: removeStack } = useImpartIpcCall(window.stackApi.remove, [])
   const { callIpc: setCover } = useImpartIpcCall(window.stackApi.setCover, [])
+  const { callIpc: detachSourceFile } = useImpartIpcCall(window.taggableApi.detachSourceFile, [])
 
   const { reload, stackTrail } = useTaggables()
 
@@ -140,6 +142,15 @@ export function useTaggableContextMenuOptions(
             }
           }
         )
+    },
+    {
+      icon: <LinkOffIcon />,
+      label: 'Detach Source File',
+      hide: !selection.some(isTaggableImage),
+      onClick: async () => {
+        await detachSourceFile(selection.filter(isTaggableImage).map((s) => s.id))
+        reload()
+      }
     },
     'divider',
     {


### PR DESCRIPTION
Resolves #24 

Added a filter to allow showing and hiding non-image (source) files with the following options:

<img width="260" height="284" alt="image" src="https://github.com/user-attachments/assets/f77c40e8-d1e8-4731-b314-5c4559774ef9" />

Additionally, you can now detach an image file from a source file:

<img width="221" height="257" alt="image" src="https://github.com/user-attachments/assets/d87d4e01-1ddb-452b-8aec-f61904d7bd4c" />
