### PR TITLE
Better Logging

### DIFF
--- a/src/main/api/commonApi.ts
+++ b/src/main/api/commonApi.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 import { store } from '../config'
 import { handleError } from '../common/handleError'
 import { impartApp } from '..'
+import logger from 'electron-log'
 
 //It turns out according to the electron-store docs (https://github.com/sindresorhus/electron-store?tab=readme-ov-file#how-do-i-get-store-values-in-the-renderer-process-when-my-store-was-initialized-in-the-main-process)
 // even though the store should work in the renderer, you can't actually use it
@@ -22,6 +23,7 @@ export function setupCommonApi() {
     handleError(() => {
       store.set(key, value)
       impartApp.mainWindow?.webContents.send('common/configUpdated', { key, value })
+      logger.info(`Updated the ${key} setting to ${JSON.stringify(value)}`)
     })
   )
 }

--- a/src/main/common/handleError.ts
+++ b/src/main/common/handleError.ts
@@ -1,3 +1,5 @@
+import logger from 'electron-log'
+
 export interface ImpartError {
   message: string
   stack?: string
@@ -22,7 +24,7 @@ export async function handleError<T>(func: () => T | Promise<T>): Promise<T | Im
       }
     }
 
-    console.error(e)
+    logger.error(e)
     return error
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,11 +13,10 @@ import { setupStackApi } from './api/stackApi'
 import { ThumbnailManager } from './indexables/thumbnailManager'
 import { store } from './config'
 import { autoUpdater } from 'electron-updater'
-import electronLog from 'electron-log'
 import { setupCommonApi } from './api/commonApi'
+import { initLogging } from './initLogging'
 
-electronLog.transports.file.level = 'info'
-autoUpdater.logger = electronLog
+initLogging()
 
 if (store.get('autoUpdatingEnabled')) {
   autoUpdater.checkForUpdatesAndNotify()

--- a/src/main/indexables/directoryManager.ts
+++ b/src/main/indexables/directoryManager.ts
@@ -8,6 +8,7 @@ import { IndexingManager } from './indexingManager'
 import { zap } from '../common/zap'
 import { TaggingManager } from '../tagging/taggingManager'
 import { readdir } from 'fs/promises'
+import logger from 'electron-log'
 
 interface DirectoryPayload {
   path: string
@@ -56,6 +57,7 @@ export namespace DirectoryManager {
         await updateDirectory(directory, payload)
       } else if (directory && !payload) {
         await directory.remove()
+        logger.info(`Removed the "${directory.path}" directory`)
       }
     }
   }
@@ -72,6 +74,8 @@ export namespace DirectoryManager {
 
     await directory.save()
     await IndexingManager.indexFiles(directory)
+
+    logger.info(`Added the "${directory.path}" directory to the index`)
   }
 
   async function updateDirectory(directory: Directory, payload: DirectoryPayload) {
@@ -89,6 +93,8 @@ export namespace DirectoryManager {
           : await Tag.findBy({ id: In(payload.autoTags) })
 
       directory.autoTags = nextTags
+
+      logger.info(`Updated the "${directory.path}" directory settings`)
     }
 
     const recursionChanged = directory.recursive != payload.recursive

--- a/src/main/indexables/directoryManager.ts
+++ b/src/main/indexables/directoryManager.ts
@@ -56,8 +56,8 @@ export namespace DirectoryManager {
       } else if (directory && payload) {
         await updateDirectory(directory, payload)
       } else if (directory && !payload) {
+        logger.info(`Removing the "${directory.path}" directory`)
         await directory.remove()
-        logger.info(`Removed the "${directory.path}" directory`)
       }
     }
   }

--- a/src/main/indexables/indexingManager.ts
+++ b/src/main/indexables/indexingManager.ts
@@ -150,6 +150,7 @@ export namespace IndexingManager {
     } else if (item.taggable && item.fileName && item.date) {
       await updateIndex(item.taggable, item.date)
     } else if (item.taggable && !item.fileName) {
+      logger.info(`Removing indexed item: ${item.taggable.fileIndex.fileName}`)
       await item.taggable.remove()
     }
   }

--- a/src/main/indexables/indexingManager.ts
+++ b/src/main/indexables/indexingManager.ts
@@ -15,6 +15,7 @@ import { ThumbnailManager } from './thumbnailManager'
 import { zap } from '../common/zap'
 import { TaggingManager } from '../tagging/taggingManager'
 import { store } from '../config'
+import logger from 'electron-log'
 
 export namespace IndexingManager {
   let isIndexing = false
@@ -27,7 +28,7 @@ export namespace IndexingManager {
 
   export async function indexAll() {
     if (isIndexing) {
-      console.log('Indexing skipped: Indexing is already in progress')
+      logger.info('Indexing skipped: Indexing is already in progress')
       return
     }
 
@@ -38,7 +39,7 @@ export namespace IndexingManager {
       const directories = await Directory.find({ relations: { autoTags: true } })
 
       for (const directory of directories) {
-        console.log('Indexing:', directory.path)
+        logger.info('Indexing:', directory.path)
         const changesDetected = await indexFiles(directory)
 
         if (changesDetected) {
@@ -54,7 +55,7 @@ export namespace IndexingManager {
 
   export async function indexFiles(directory: Directory) {
     if (!existsSync(directory.path)) {
-      console.log('Directory no longer exists! Removing...')
+      logger.info('Directory no longer exists! Removing...')
       await directory.remove()
       return true
     }
@@ -166,7 +167,7 @@ export namespace IndexingManager {
   }
 
   async function indexImage(filePath: string, directory: Directory) {
-    console.log('Indexing Image: ', filePath)
+    logger.info('Indexing Image: ', filePath)
     const [size, stats] = await Promise.all([
       await imageSizeFromFile(filePath),
       await stat(filePath)
@@ -186,7 +187,7 @@ export namespace IndexingManager {
   }
 
   async function indexFile(filePath: string, directory: Directory) {
-    console.log('Indexing File: ', filePath)
+    logger.info('Indexing File: ', filePath)
 
     const indexedFile = TaggableFile.create({
       fileIndex: { path: filePath, fileName: path.basename(filePath) },
@@ -225,7 +226,7 @@ export namespace IndexingManager {
         )
       }
 
-      console.log('Associating indexed image with: ', possibleSourceFiles[0].fileIndex.path)
+      logger.info('Associating indexed image with: ', possibleSourceFiles[0].fileIndex.path)
       image.source = possibleSourceFiles[0]
 
       if (image.tags.length == 0 && store.get('applyTagsOnSourceAssociation')) {

--- a/src/main/initLogging.ts
+++ b/src/main/initLogging.ts
@@ -11,4 +11,6 @@ export function initLogging() {
 
   electronLog.transports.file.resolvePathFn = () =>
     path.join(appData, 'impart/logs', import.meta.env.DEV ? 'dev.log' : 'main.log')
+
+  electronLog.errorHandler.startCatching()
 }

--- a/src/main/initLogging.ts
+++ b/src/main/initLogging.ts
@@ -1,0 +1,14 @@
+import { app } from 'electron'
+import electronLog from 'electron-log'
+import { autoUpdater } from 'electron-updater'
+import path from 'path'
+
+export function initLogging() {
+  electronLog.transports.file.level = 'info'
+  autoUpdater.logger = electronLog
+
+  const appData = app.getPath('appData')
+
+  electronLog.transports.file.resolvePathFn = () =>
+    path.join(appData, 'impart/logs', import.meta.env.DEV ? 'dev.log' : 'main.log')
+}

--- a/src/main/tagging/stackManager.ts
+++ b/src/main/tagging/stackManager.ts
@@ -1,9 +1,11 @@
 import { In } from 'typeorm'
 import { Taggable } from '../database/entities/Taggable'
 import { TaggableImage, isTaggableImage } from '../database/entities/TaggableImage'
-import { TaggableStack } from '../database/entities/TaggableStack'
+import { isTaggableStack, TaggableStack } from '../database/entities/TaggableStack'
 import { ImpartTask, TaskType } from '../task/impartTask'
 import { taskQueue } from '../task/taskQueue'
+import logger from 'electron-log'
+import { TaggableFile } from '../database/entities/TaggableFile'
 
 export namespace StackManager {
   export async function create(
@@ -30,6 +32,8 @@ export namespace StackManager {
       parent,
       tags: findCommonTags(childTaggables)
     })
+
+    logger.info(`Created a new "${name}" stack containing ${buildTaggableString(childTaggables)}`)
 
     await stack.save()
   }
@@ -61,14 +65,26 @@ export namespace StackManager {
     )
 
     if (currentStackId) {
-      await validateStackCover(currentStackId)
+      const stack = await TaggableStack.findOneOrFail({
+        where: { id: stackId },
+        relations: { taggables: true }
+      })
+
+      await validateStackCover(stack)
+
+      logger.info(`Added ${buildTaggableString(childTaggables)} to the "${stack.name}" stack`)
+    } else {
+      logger.info(`Moved ${buildTaggableString(childTaggables)} back to the root`)
     }
   }
 
   export async function rename(stackId: number, name: string) {
     const stack = await TaggableStack.findOneByOrFail({ id: stackId })
+    const oldName = stack.name
     stack.name = name
     await stack.save()
+
+    logger.info(`Renamed the "${oldName}" stack to "${name}"`)
   }
 
   export async function setCover(stackId: number, coverId: number) {
@@ -83,6 +99,8 @@ export namespace StackManager {
 
     stack.cover = cover
     await stack.save()
+
+    logger.info(`Updated the cover of the "${stack.name}" stack`)
   }
 
   export async function moveTaggablesToHome(taggableIds: number[], currentStackId: number) {
@@ -91,19 +109,36 @@ export namespace StackManager {
       relations: { taggables: true }
     })
 
+    const removedTaggables = stack.taggables!.filter((t) => taggableIds.some((id) => t.id === id))
+
     //Remove all target taggables from this stack (which will send them to the home stack)
     stack.taggables = stack.taggables!.filter((t) => !taggableIds.some((id) => t.id === id))
     await stack.save()
 
-    await validateStackCover(currentStackId)
+    logger.info(`Moved ${buildTaggableString(removedTaggables)} to the back to the root`)
+
+    await validateStackCover(stack)
   }
 
-  async function validateStackCover(stackId: number) {
-    const stack = await TaggableStack.findOneOrFail({
-      where: { id: stackId },
-      relations: { taggables: true }
-    })
+  function buildTaggableString(taggables: Taggable[]) {
+    if (taggables.length == 1) {
+      return `"${getTaggableName(taggables[0])}"`
+    } else if (taggables.length <= 4) {
+      return `${taggables.length} items (${taggables.map(getTaggableName).join(', ')})`
+    } else if (taggables.length > 4) {
+      return `${taggables.length} items`
+    }
 
+    return ''
+  }
+
+  function getTaggableName(taggable: Taggable) {
+    return isTaggableStack(taggable)
+      ? taggable.name
+      : (taggable as TaggableImage | TaggableFile).fileIndex.fileName
+  }
+
+  async function validateStackCover(stack: TaggableStack) {
     if (!stack.taggables?.some((t) => t.id === stack.cover?.id)) {
       stack.cover = stack.taggables?.find(isTaggableImage) ?? null
       await stack.save()
@@ -138,6 +173,8 @@ export namespace StackManager {
     }
 
     await stack.remove()
+
+    logger.info(`Exploded the "${stack.name}" stack`)
   }
 
   //CURRENTLY UNUSED. Finds all stacks with 0 or 1 items and removes them

--- a/src/main/tagging/tagManager.ts
+++ b/src/main/tagging/tagManager.ts
@@ -86,7 +86,7 @@ export namespace TagManager {
       await manager.remove(groupEntity)
     })
 
-    logger.info(`Deleted tag group ${groupEntity.label ?? 'Unnamed Group'}`)
+    logger.info(`Deleted tag group "${groupEntity.label ?? 'Unnamed Group'}"`)
 
     return true
   }

--- a/src/main/tagging/tagManager.ts
+++ b/src/main/tagging/tagManager.ts
@@ -2,6 +2,7 @@ import { arrayMoveImmutable } from '../common/arrayMove'
 import { AppDataSource } from '../database/database'
 import { Tag } from '../database/entities/Tag'
 import { TagGroup } from '../database/entities/TagGroup'
+import logger from 'electron-log'
 
 export namespace TagManager {
   export async function getTagGroups() {
@@ -22,6 +23,8 @@ export namespace TagManager {
     })
     await group.save()
 
+    logger.info('Created new tag group')
+
     return group
   }
 
@@ -32,6 +35,8 @@ export namespace TagManager {
     groupEntity.defaultTagColor = defaultTagColor
 
     await groupEntity.save()
+
+    logger.info(`Edited tag group "${label ?? 'Unnamed Group'}"`)
 
     return groupEntity
   }
@@ -69,6 +74,8 @@ export namespace TagManager {
         await group.save()
       })
     )
+
+    logger.info('Reordered tag groups')
   }
 
   export async function deleteGroup(id: number) {
@@ -78,6 +85,8 @@ export namespace TagManager {
       await Promise.all(groupEntity.tags.map((t) => manager.remove(t)))
       await manager.remove(groupEntity)
     })
+
+    logger.info(`Deleted tag group ${groupEntity.label ?? 'Unnamed Group'}`)
 
     return true
   }
@@ -99,6 +108,8 @@ export namespace TagManager {
     })
 
     await tag.save()
+
+    logger.info(`Created new tag in the "${tagGroup.label}" group`)
 
     return tag
   }
@@ -123,6 +134,8 @@ export namespace TagManager {
 
     await tagEntity.save()
 
+    logger.info(`Updated "${tagEntity.label ?? 'Unnamed Tag'}" tag`)
+
     return tagEntity
   }
 
@@ -143,6 +156,8 @@ export namespace TagManager {
     if (oldGroup.id != nextGroup.id) {
       await rejigTagOrder(oldGroup.id)
     }
+
+    logger.info('Reordered tags')
   }
 
   async function insertTagIntoGroup(tag: Tag, group: TagGroup, beforeId: number | 'end') {
@@ -204,6 +219,8 @@ export namespace TagManager {
   export async function deleteTag(id: number) {
     const tagEntity = await Tag.findOneByOrFail({ id })
     await tagEntity.remove()
+
+    logger.info(`Deleted "${tagEntity.label ?? 'Unnamed Tag'}" tag`)
     return true
   }
 }

--- a/src/main/tagging/taggingManager.ts
+++ b/src/main/tagging/taggingManager.ts
@@ -6,6 +6,8 @@ import { taskQueue } from '../task/taskQueue'
 import { TaggableImage } from '../database/entities/TaggableImage'
 import { TaggableFile } from '../database/entities/TaggableFile'
 import { ImpartTask, TaskType } from '../task/impartTask'
+import logger from 'electron-log'
+import { isTaggableStack } from '../database/entities/TaggableStack'
 
 export namespace TaggingManager {
   export async function setFileTags(taggableId: number, tagIds: number[]) {
@@ -18,8 +20,12 @@ export namespace TaggingManager {
       throw new Error(`Could not find taggable with id ${taggableId}`)
     }
 
+    const beforeTags = file.tags
+
     file.tags = tags
     await file.save()
+
+    logTagChange(beforeTags, tags, file)
   }
 
   export async function bulkTag(taggableIds: number[], tagIds: number[]) {
@@ -40,18 +46,46 @@ export namespace TaggingManager {
   }
 
   async function addTagsToTaggable(taggable: Taggable, tags: Tag[]) {
-    let added = false
+    const addedTags: Tag[] = []
 
     tags.forEach((addedTag) => {
       if (!taggable.tags.some((existingTag) => existingTag.id === addedTag.id)) {
-        added = true
+        addedTags.push(addedTag)
         taggable.tags.push(addedTag)
       }
     })
 
-    if (added) {
+    if (addedTags.length > 0) {
       await taggable.save()
+      logTagChange([], addedTags, taggable)
     }
+  }
+
+  function logTagChange(before: Tag[], after: Tag[], taggable: Taggable) {
+    const removedTags = before.filter((b) => !after.some((a) => a.id == b.id))
+    const addedTags = after.filter((a) => !before.some((b) => a.id == b.id))
+
+    const taggableName = isTaggableStack(taggable)
+      ? taggable.name
+      : (taggable as TaggableFile | TaggableImage).fileIndex.fileName
+
+    if (removedTags.length > 0) {
+      if (addedTags.length > 0) {
+        logger.info(
+          `Removed ${tagArrayToString(removedTags)} and added ${tagArrayToString(addedTags)} to ${taggableName}`
+        )
+      } else {
+        logger.info(`Removed ${tagArrayToString(removedTags)} from ${taggableName}`)
+      }
+    } else {
+      logger.info(`Added ${tagArrayToString(addedTags)} to ${taggableName}`)
+    }
+  }
+
+  function tagArrayToString(tags: Tag[]) {
+    return tags.length == 1
+      ? `"${tags[0].label ?? 'Unnamed'}"`
+      : `${tags.length} tags (${tags.map((t) => t.label ?? 'Unnamed Tag').join(', ')})`
   }
 
   abstract class BaseBulkTagTask extends ImpartTask<Taggable> {


### PR DESCRIPTION
Resolves #30 

- All main thread are now fed into the electron logger instead of just going to the console log
- Dev and prod logs are now split into two separate files
- Added a whole bunch of logging all over the main thread of the app
- Any and all errors on the main thread are now logged as well