### PR TITLE
Disable Drag & Drop on Bulk Tag

### DIFF
--- a/src/renderer/src/BulkTag.tsx
+++ b/src/renderer/src/BulkTag.tsx
@@ -5,6 +5,7 @@ import { Tag } from './Common/Components/Tag/Tag'
 import CheckIcon from '@mui/icons-material/CheckRounded'
 import { Backable } from './Common/Components/Backable'
 import { VirtualTaggableGrid } from './Common/Components/TaggableGrid'
+import { DisableDragging } from './Common/Components/DragAndDrop/DisableDragging'
 
 export interface BulkTagProps {
   items: Impart.Taggable[]
@@ -61,7 +62,9 @@ export function BulkTag({ items, onFinish }: BulkTagProps) {
         <Box width={500}>
           <Card sx={{ height: '100%' }}>
             <CardContent sx={{ height: '100%', overflowY: 'auto' }}>
-              <TagSelector selection={tagSelection} onSelectionChange={setTagSelection} />
+              <DisableDragging>
+                <TagSelector selection={tagSelection} onSelectionChange={setTagSelection} />
+              </DisableDragging>
             </CardContent>
           </Card>
         </Box>

--- a/src/renderer/src/Common/Components/DragAndDrop/DisableDragging.tsx
+++ b/src/renderer/src/Common/Components/DragAndDrop/DisableDragging.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext } from 'react'
+
+export interface DisableDraggingData {
+  disable: true
+}
+
+const DisableDraggingContext = createContext<DisableDraggingData | null>(null)
+
+export interface DisableDraggingProps {
+  children?: React.ReactNode
+}
+
+export function DisableDragging({ children }: DisableDraggingProps) {
+  return (
+    <DisableDraggingContext.Provider value={{ disable: true }}>
+      {children}
+    </DisableDraggingContext.Provider>
+  )
+}
+
+//Rather than passing around a disabled prop with a true or false, we use the mere
+// presence of the context to disable dragging for everything below
+export function useDisableDragging() {
+  return useContext(DisableDraggingContext)
+}

--- a/src/renderer/src/Common/Components/DragAndDrop/Draggable.tsx
+++ b/src/renderer/src/Common/Components/DragAndDrop/Draggable.tsx
@@ -2,6 +2,7 @@ import { useDraggable } from '@dnd-kit/core'
 import { Box } from '@mui/material'
 import React, { useId } from 'react'
 import { DraggableHandleProvider } from './DraggableHandleProvider'
+import { useDisableDragging } from './DisableDragging'
 
 export type DraggableType = 'taggable' | 'tag' | 'tagGroup'
 
@@ -21,13 +22,15 @@ export interface DraggableProps {
 export function Draggable({ children, id, type, exposeHandle, disabled }: DraggableProps) {
   const draggableId = useId()
 
+  const actualDisabled = disabled || useDisableDragging()?.disable
+
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: draggableId,
     data: {
       id,
       type
     } satisfies DraggableData,
-    disabled
+    disabled: actualDisabled
   })
 
   if (!exposeHandle) {

--- a/src/renderer/src/Common/Components/TagSelector/TagGroup.tsx
+++ b/src/renderer/src/Common/Components/TagSelector/TagGroup.tsx
@@ -10,6 +10,7 @@ import { useImpartIpcCall } from '@renderer/Common/Hooks/useImpartIpc'
 import { GroupTagList } from './GroupTagList'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import { useDisableDragging } from '../DragAndDrop/DisableDragging'
 
 export interface TagGroupProps {
   group: Impart.TagGroup
@@ -64,6 +65,7 @@ export function TagGroup({
   }
 
   const dragHandle = useDraggableHandle()
+  const dragDisabled = useDisableDragging()
 
   return (
     <Box
@@ -81,17 +83,20 @@ export function TagGroup({
       <EditTagGroup group={group} show={editMode} onClose={() => setEditMode(false)} />
       {!editMode && (
         <Stack direction="row" gap={1}>
-          <Stack
-            justifyContent="center"
-            borderRadius={2}
-            sx={(theme) => ({
-              transition: '0.2s',
-              '&:hover': { bgcolor: darken(theme.palette.background.paper, 0.1) }
-            })}
-            {...dragHandle}
-          >
-            <DragIndicatorIcon />
-          </Stack>
+          {!dragDisabled?.disable && (
+            <Stack
+              justifyContent="center"
+              borderRadius={2}
+              sx={(theme) => ({
+                transition: '0.2s',
+                '&:hover': { bgcolor: darken(theme.palette.background.paper, 0.1) }
+              })}
+              {...dragHandle}
+            >
+              <DragIndicatorIcon />
+            </Stack>
+          )}
+
           <Box flex={1}>
             <Stack direction="row" alignItems="center" justifyContent="space-between">
               <Typography variant="h5" onClick={() => setEditMode(true)}>


### PR DESCRIPTION
Drag & drop on the tag selector on the bulk tag screen is now disabled (via a fancy `<DisableDragging>` component that just disabled all drag & drop below it)