### PR TITLE
Display order setting for tags on edit tag popup

### DIFF
--- a/src/main/api/commonApi.ts
+++ b/src/main/api/commonApi.ts
@@ -22,7 +22,6 @@ export function setupCommonApi() {
   ipcMain.on('common/setConfigItem', async (_e, key: string, value: any) =>
     handleError(() => {
       store.set(key, value)
-      impartApp.mainWindow?.webContents.send('common/configUpdated', { key, value })
       logger.info(`Updated the ${key} setting to ${JSON.stringify(value)}`)
     })
   )

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -11,6 +11,7 @@ interface Config {
   autoUpdatingEnabled: boolean
   applyTagsOnSourceAssociation: boolean
   showPatchNotesOnUpdate: boolean
+  taggableTagOrder: 'applied' | 'alphabetical' | 'sideBar'
 }
 
 const schema: Schema<Config> = {
@@ -28,6 +29,9 @@ const schema: Schema<Config> = {
   },
   showPatchNotesOnUpdate: {
     default: true
+  },
+  taggableTagOrder: {
+    default: 'applied'
   }
 }
 

--- a/src/main/tagging/taggingManager.ts
+++ b/src/main/tagging/taggingManager.ts
@@ -77,7 +77,7 @@ export namespace TaggingManager {
       } else {
         logger.info(`Removed ${tagArrayToString(removedTags)} from ${taggableName}`)
       }
-    } else {
+    } else if (addedTags.length > 0) {
       logger.info(`Added ${tagArrayToString(addedTags)} to ${taggableName}`)
     }
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -10,6 +10,7 @@ declare global {
       autoUpdatingEnabled: boolean
       applyTagsOnSourceAssociation: boolean
       showPatchNotesOnUpdate: boolean
+      taggableTagOrder: 'applied' | 'alphabetical' | 'sideBar'
     }
 
     interface Dimensions {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -123,7 +123,6 @@ declare global {
         key: Key,
         value: Impart.ConfigItems[Key]
       ) => Result<void>
-      onConfigUpdated: CallbackFunc<{ key: string; value: any }>
     }
 
     fileApi: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -21,8 +21,7 @@ function generateCallback(channel: string) {
 
 contextBridge.exposeInMainWorld('commonApi', {
   getConfigItem: generateEndpoint('common/getConfigItem'),
-  setConfigItem: generateCommand('common/setConfigItem'),
-  onConfigUpdated: generateCallback('common/configUpdated')
+  setConfigItem: generateCommand('common/setConfigItem')
 })
 
 contextBridge.exposeInMainWorld('fileApi', {

--- a/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
+++ b/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
@@ -49,11 +49,15 @@ export function EditTags({ tags, removeTag }: EditTagsProps) {
           .slice()
           .sort((a, b) => (a.label ?? 'Unnamed Tag').localeCompare(b.label ?? 'Unnamed Tag'))
       case 'sideBar':
-        return tags
-          .slice()
-          .map((t) => findOrder(t, groups))
-          .sort((a, b) => compareTagOrder(a, b))
-          .map((t) => t.tag)
+        return (
+          tags
+            //We figure out what the order of a group a tag belongs to before we do our search
+            // instead of during our search since the latter would result in group searches
+            // happening every single comparison
+            .map((t) => findOrder(t, groups))
+            .sort((a, b) => compareTagOrder(a, b))
+            .map((t) => t.tag) //And then we map everything back to tags
+        )
     }
   }, [tags, displayOrder, groups])
 

--- a/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
+++ b/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
@@ -1,12 +1,46 @@
 import { Stack, Typography, Grid } from '@mui/material'
 import { Tag } from '../Tag/Tag'
+import { useSetting } from '@renderer/Common/Contexts/SettingsProvider'
+import { useMemo } from 'react'
+import { useTagGroups } from '@renderer/EntityProviders/TagProvider'
 
 export interface EditTagsProps {
   tags: Impart.Tag[]
   removeTag?: (t: Impart.Tag) => void
 }
 
+function compareTagOrder(first: Impart.Tag, second: Impart.Tag, groups?: Impart.TagGroup[]) {
+  if (!groups) {
+    return 0
+  }
+
+  const firstGroup = groups.find((g) => g.tags?.some((t) => t.id === first.id))
+  const secondGroup = groups.find((g) => g.tags?.some((t) => t.id === second.id))
+
+  if (firstGroup?.id != secondGroup?.id) {
+    return (firstGroup?.groupOrder ?? 0) - (secondGroup?.groupOrder ?? 0)
+  }
+
+  return first.tagOrder - second.tagOrder
+}
+
 export function EditTags({ tags, removeTag }: EditTagsProps) {
+  const { setting: displayOrder } = useSetting('taggableTagOrder')
+  const { groups } = useTagGroups()
+
+  const orderedTags = useMemo(() => {
+    switch (displayOrder) {
+      case 'applied':
+        return tags
+      case 'alphabetical':
+        return tags
+          .slice()
+          .sort((a, b) => (a.label ?? 'Unnamed Tag').localeCompare(b.label ?? 'Unnamed Tag'))
+      case 'sideBar':
+        return tags.slice().sort((a, b) => compareTagOrder(a, b, groups))
+    }
+  }, [tags, displayOrder, groups])
+
   return (
     <Stack p={2} gap={2}>
       <Typography textAlign="center" variant="h6">
@@ -14,7 +48,7 @@ export function EditTags({ tags, removeTag }: EditTagsProps) {
       </Typography>
       {tags.length > 0 && (
         <Grid container maxWidth={360} spacing={1} justifyContent={'center'}>
-          {tags.map((t) => (
+          {orderedTags?.map((t) => (
             <Grid key={t.id}>
               <Tag tag={t} onSelect={() => removeTag && removeTag(t)} />
             </Grid>

--- a/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
+++ b/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
@@ -15,16 +15,9 @@ interface TagOrder {
 }
 
 function findOrder(tag: Impart.Tag, groups?: Impart.TagGroup[]): TagOrder {
-  if (!groups) {
-    return {
-      tag,
-      groupOrder: 0
-    }
-  }
-
   return {
     tag,
-    groupOrder: groups.find((g) => g.tags?.some((t) => t.id === tag.id))?.groupOrder ?? 0
+    groupOrder: groups?.find((g) => g.tags?.some((t) => t.id === tag.id))?.groupOrder ?? 0
   }
 }
 

--- a/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
+++ b/src/renderer/src/Common/Components/TaggableDisplay/EditTags.tsx
@@ -9,19 +9,31 @@ export interface EditTagsProps {
   removeTag?: (t: Impart.Tag) => void
 }
 
-function compareTagOrder(first: Impart.Tag, second: Impart.Tag, groups?: Impart.TagGroup[]) {
+interface TagOrder {
+  tag: Impart.Tag
+  groupOrder: number
+}
+
+function findOrder(tag: Impart.Tag, groups?: Impart.TagGroup[]): TagOrder {
   if (!groups) {
-    return 0
+    return {
+      tag,
+      groupOrder: 0
+    }
   }
 
-  const firstGroup = groups.find((g) => g.tags?.some((t) => t.id === first.id))
-  const secondGroup = groups.find((g) => g.tags?.some((t) => t.id === second.id))
+  return {
+    tag,
+    groupOrder: groups.find((g) => g.tags?.some((t) => t.id === tag.id))?.groupOrder ?? 0
+  }
+}
 
-  if (firstGroup?.id != secondGroup?.id) {
-    return (firstGroup?.groupOrder ?? 0) - (secondGroup?.groupOrder ?? 0)
+function compareTagOrder(first: TagOrder, second: TagOrder) {
+  if (first.groupOrder != second.groupOrder) {
+    return first.groupOrder - second.groupOrder
   }
 
-  return first.tagOrder - second.tagOrder
+  return first.tag.tagOrder - second.tag.tagOrder
 }
 
 export function EditTags({ tags, removeTag }: EditTagsProps) {
@@ -37,7 +49,11 @@ export function EditTags({ tags, removeTag }: EditTagsProps) {
           .slice()
           .sort((a, b) => (a.label ?? 'Unnamed Tag').localeCompare(b.label ?? 'Unnamed Tag'))
       case 'sideBar':
-        return tags.slice().sort((a, b) => compareTagOrder(a, b, groups))
+        return tags
+          .slice()
+          .map((t) => findOrder(t, groups))
+          .sort((a, b) => compareTagOrder(a, b))
+          .map((t) => t.tag)
     }
   }, [tags, displayOrder, groups])
 

--- a/src/renderer/src/Common/Contexts/SettingsProvider.tsx
+++ b/src/renderer/src/Common/Contexts/SettingsProvider.tsx
@@ -1,0 +1,85 @@
+import { useNotification } from '@renderer/Common/Components/NotificationProvider'
+import { resolve, useImpartIpcCall, useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
+import { produce } from 'immer'
+import { createContext, useCallback, useContext, useEffect } from 'react'
+
+type RendererSettings = Omit<Impart.ConfigItems, 'previousVersion'>
+
+export interface SettingsData {
+  settings?: RendererSettings
+  isLoading: boolean
+  updateSetting: (key: keyof Impart.ConfigItems, value: any) => void
+}
+
+const SettingsContext = createContext<SettingsData | null>(null)
+
+async function get<Key extends keyof Impart.ConfigItems>(
+  key: Key,
+  defaultValue: Impart.ConfigItems[Key],
+  sendError: (value: string) => void
+) {
+  return resolve(await window.commonApi.getConfigItem(key), sendError)?.result ?? defaultValue
+}
+
+export interface SettingsProviderProps {
+  children?: React.ReactNode
+}
+
+export function SettingsProvider({ children }: SettingsProviderProps) {
+  const { sendError } = useNotification()
+
+  const {
+    data: settings,
+    isLoading,
+    setData: setSettings
+  } = useImpartIpcData(
+    async (): Promise<RendererSettings> => ({
+      applyTagsOnSourceAssociation: await get('applyTagsOnSourceAssociation', true, sendError),
+      autoUpdatingEnabled: await get('autoUpdatingEnabled', true, sendError),
+      showPatchNotesOnUpdate: await get('showPatchNotesOnUpdate', true, sendError)
+    }),
+    [sendError]
+  )
+
+  const updateSetting = useCallback(
+    async (key: keyof Impart.ConfigItems, value: any) => {
+      await window.commonApi.setConfigItem(key, value)
+
+      setSettings(
+        produce(settings, (s) => {
+          if (s) {
+            s[key] = value
+          }
+
+          return s
+        })
+      )
+    },
+    [settings]
+  )
+
+  return (
+    <SettingsContext.Provider value={{ settings, isLoading, updateSetting }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSetting<Key extends keyof RendererSettings>(key: Key) {
+  const result = useContext(SettingsContext)
+
+  if (!result) {
+    throw new Error('useSettings() cannot be used without being wrapped by a SettingsProvider')
+  }
+
+  const updateSetting = useCallback(
+    (value: RendererSettings[Key]) => result.updateSetting(key, value),
+    [result.updateSetting, key]
+  )
+
+  return {
+    setting: result.settings ? result.settings[key] : undefined,
+    isLoading: result.isLoading,
+    updateSetting
+  }
+}

--- a/src/renderer/src/Common/Contexts/SettingsProvider.tsx
+++ b/src/renderer/src/Common/Contexts/SettingsProvider.tsx
@@ -36,7 +36,8 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
     async (): Promise<RendererSettings> => ({
       applyTagsOnSourceAssociation: await get('applyTagsOnSourceAssociation', true, sendError),
       autoUpdatingEnabled: await get('autoUpdatingEnabled', true, sendError),
-      showPatchNotesOnUpdate: await get('showPatchNotesOnUpdate', true, sendError)
+      showPatchNotesOnUpdate: await get('showPatchNotesOnUpdate', true, sendError),
+      taggableTagOrder: await get('taggableTagOrder', 'applied', sendError)
     }),
     [sendError]
   )

--- a/src/renderer/src/Common/Hooks/useImpartIpc.ts
+++ b/src/renderer/src/Common/Hooks/useImpartIpc.ts
@@ -15,16 +15,23 @@ export function useImpartIpcCall<Params extends any[], Result>(
       const result = await call(...params)
       setLoading(false)
 
-      if (isNotError(result)) {
-        return result
-      } else if (isError(result)) {
-        sendError(result.message)
-      }
+      return resolve(result, sendError)
     },
     [...deps, sendError]
   )
 
   return { callIpc, isLoading }
+}
+
+export function resolve<T>(
+  result: T | Impart.Error,
+  onError: (result: string) => void
+): Exclude<T | Impart.Error, Impart.Error> | undefined {
+  if (isNotError(result)) {
+    return result
+  } else if (isError(result)) {
+    onError(result.message)
+  }
 }
 
 function isNotError<T>(
@@ -65,5 +72,5 @@ export function useImpartIpcData<Result>(
     loadData()
   }, [loadData])
 
-  return { data, isLoading, reload: loadData, ...everythingElse }
+  return { data, isLoading, setData, reload: loadData, ...everythingElse }
 }

--- a/src/renderer/src/PatchNotes/useShowPatchNotes.ts
+++ b/src/renderer/src/PatchNotes/useShowPatchNotes.ts
@@ -1,3 +1,4 @@
+import { useSetting } from '@renderer/Common/Contexts/SettingsProvider'
 import { useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
 import { useState, useEffect } from 'react'
 
@@ -9,16 +10,14 @@ export function useShowPatchNotes() {
     []
   )
 
-  const { data: showPatchNotesOnUpdate, isLoading: loadingShowPatchNotes } = useImpartIpcData(
-    () => window.commonApi.getConfigItem('showPatchNotesOnUpdate'),
-    []
-  )
+  const { setting: showPatchNotesOnUpdate, isLoading: loadingShowPatchNotes } =
+    useSetting('showPatchNotesOnUpdate')
 
   useEffect(() => {
     if (
       !loadingVersion &&
       !loadingShowPatchNotes &&
-      showPatchNotesOnUpdate?.result &&
+      showPatchNotesOnUpdate &&
       previousVersion?.result != import.meta.env.PACKAGE_VERSION
     ) {
       setShow(true)

--- a/src/renderer/src/Settings/Tagging.tsx
+++ b/src/renderer/src/Settings/Tagging.tsx
@@ -1,21 +1,83 @@
-import { Box, Stack, Typography } from '@mui/material'
+import { Box, FormControlLabel, Radio, RadioGroup, Stack, Typography } from '@mui/material'
 import { ToggleSetting } from './ToggleSetting'
+import { useSetting } from '@renderer/Common/Contexts/SettingsProvider'
 
 export interface TaggingProps {}
 
 export function Tagging({}: TaggingProps) {
+  const { setting, updateSetting } = useSetting('taggableTagOrder')
+
   return (
     <Box>
       <Stack mt={1} mb={2} direction="row" gap={2} alignItems="center">
         <Typography variant="h3">Tagging</Typography>
       </Stack>
-      <ToggleSetting
-        storeKey="applyTagsOnSourceAssociation"
-        title="Apply source tags to image on association"
-        subtitle={
-          'Copies all tags from the source file to the image file upon association. Only occurs if the image has no tags.'
-        }
-      />
+      <Stack gap={4}>
+        <ToggleSetting
+          storeKey="applyTagsOnSourceAssociation"
+          title="Apply source tags to image on association"
+          subtitle={
+            'Copies all tags from the source file to the image file upon association. Only occurs if the image has no tags.'
+          }
+        />
+        <Box flex={1} ml={10}>
+          <Typography fontWeight="bold">Displayed order of tags on a specific file</Typography>
+          <Typography variant="body2">
+            Determines what order the tags will show up on the little popup panel when editing tags
+            on a specific file.
+          </Typography>
+          <RadioGroup
+            value={setting}
+            row
+            sx={{ mt: 1, gap: 2 }}
+            onChange={(e) =>
+              updateSetting(e.target.value as Impart.ConfigItems['taggableTagOrder'])
+            }
+          >
+            <FormControlLabel
+              value={'applied'}
+              control={<Radio />}
+              label={
+                <Stack>
+                  <Typography>
+                    Order applied{' '}
+                    <Typography variant="caption" lineHeight={1}>
+                      (default)
+                    </Typography>
+                  </Typography>
+                  <Typography variant="caption" lineHeight={1}>
+                    Show tags in the order they were originally applied
+                  </Typography>
+                </Stack>
+              }
+            />
+            <FormControlLabel
+              value="sideBar"
+              control={<Radio />}
+              label={
+                <Stack>
+                  <Typography>Sidebar order</Typography>
+                  <Typography variant="caption" lineHeight={1}>
+                    Order tags according to how they're ordered in the tag selector
+                  </Typography>
+                </Stack>
+              }
+            />
+            <FormControlLabel
+              value="alphabetical"
+              control={<Radio />}
+              label={
+                <Stack>
+                  <Typography>Alphabetical order</Typography>
+                  <Typography variant="caption" lineHeight={1}>
+                    Self-explanatory, I just wanted all three options to have descriptions lol
+                  </Typography>
+                </Stack>
+              }
+            />
+          </RadioGroup>
+        </Box>
+      </Stack>
     </Box>
   )
 }

--- a/src/renderer/src/Settings/ToggleSetting.tsx
+++ b/src/renderer/src/Settings/ToggleSetting.tsx
@@ -1,4 +1,5 @@
 import { Stack, Box, Switch, Skeleton, Typography } from '@mui/material'
+import { useSetting } from '@renderer/Common/Contexts/SettingsProvider'
 import { useImpartIpcCall, useImpartIpcData } from '@renderer/Common/Hooks/useImpartIpc'
 import React, { useEffect, useState } from 'react'
 
@@ -15,30 +16,17 @@ export interface ToggleSettingProps {
 export function ToggleSetting({ storeKey, title, subtitle, small }: ToggleSettingProps) {
   const [checked, setChecked] = useState(true)
 
-  const { callIpc: setConfigItem } = useImpartIpcCall(window.commonApi.setConfigItem, [])
-
-  const { data: actualSettingValue, isLoading } = useImpartIpcData(
-    () => window.commonApi.getConfigItem(storeKey),
-    [storeKey]
-  )
+  const { setting, updateSetting, isLoading } = useSetting(storeKey)
 
   useEffect(() => {
-    if (actualSettingValue) {
-      setChecked(actualSettingValue?.result)
+    if (setting !== undefined) {
+      setChecked(setting)
     }
-  }, [actualSettingValue])
-
-  useEffect(() => {
-    return window.commonApi.onConfigUpdated(({ key, value }) => {
-      if (key === storeKey) {
-        setChecked(value)
-      }
-    })
-  }, [])
+  }, [setting])
 
   const update = (checked: boolean) => {
     setChecked(checked)
-    setConfigItem(storeKey, checked)
+    updateSetting(checked)
   }
 
   return (

--- a/src/renderer/src/Settings/Updates.tsx
+++ b/src/renderer/src/Settings/Updates.tsx
@@ -19,7 +19,7 @@ export function Updates({ onShowPatchNotes }: UpdatesProps) {
           Show Patch Notes
         </Button>
       </Stack>
-      <Stack gap={2}>
+      <Stack gap={4}>
         <ToggleSetting
           storeKey="autoUpdatingEnabled"
           title="Enable Auto Updating"

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -11,26 +11,29 @@ import { NotificationProvider } from './Common/Components/NotificationProvider'
 import { ActiveContextMenuProvider } from './Common/Components/ContextMenu/ActiveContextMenuProvider'
 import { ConfirmationDialogProvider } from './Common/Components/ConfirmationDialogProvider'
 import 'animate.css'
+import { SettingsProvider } from './Common/Contexts/SettingsProvider'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <NotificationProvider>
-      <TaskStatusProvider>
-        <DirectoryProvider>
-          <TagProvider>
-            <TaggableProvider>
-              <ThemeProvider theme={theme}>
-                <CssBaseline />
-                <ActiveContextMenuProvider>
-                  <ConfirmationDialogProvider>
-                    <Impart />
-                  </ConfirmationDialogProvider>
-                </ActiveContextMenuProvider>
-              </ThemeProvider>
-            </TaggableProvider>
-          </TagProvider>
-        </DirectoryProvider>
-      </TaskStatusProvider>
+      <SettingsProvider>
+        <TaskStatusProvider>
+          <DirectoryProvider>
+            <TagProvider>
+              <TaggableProvider>
+                <ThemeProvider theme={theme}>
+                  <CssBaseline />
+                  <ActiveContextMenuProvider>
+                    <ConfirmationDialogProvider>
+                      <Impart />
+                    </ConfirmationDialogProvider>
+                  </ActiveContextMenuProvider>
+                </ThemeProvider>
+              </TaggableProvider>
+            </TagProvider>
+          </DirectoryProvider>
+        </TaskStatusProvider>
+      </SettingsProvider>
     </NotificationProvider>
   </React.StrictMode>
 )


### PR DESCRIPTION
Resolves #25 

You can now configure the display order of the tags on the little popup that shows up below files when editing tags. Also, all of the settings go through a provider now instead of everything fetching the tags on their own and using callbacks to update things from across the app

<img width="1189" height="135" alt="image" src="https://github.com/user-attachments/assets/0be615fe-f0e6-48c6-a7ee-8011026d5911" />

---

<img width="773" height="399" alt="image" src="https://github.com/user-attachments/assets/24b0052c-e982-48e0-b236-0d1f0efc2141" />
